### PR TITLE
Check SPDX-2 expression and OSI compatibility for license

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spdx"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47317bbaf63785b53861e1ae2d11b80d6b624211d42cb20efcd210ee6f8a14bc"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3465,6 +3474,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "spdx",
  "stringcase",
  "tar",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ reqwest = { version = "0.12.4", features = ["json"] }
 serde = { version = "1.0.198", features = ["derive"] }
 serde_json = "1.0.116"
 sha1 = "0.10.6"
+spdx = "0.10"
 stringcase = "0.2.1"
 tar = "0.4.40"
 tokio = { version = "1.37.0", features = ["rt-multi-thread", "process", "fs"] }


### PR DESCRIPTION
Checks license validity according to the same rules that are [specified](https://github.com/typst/packages/tree/8b9e4ca98f75a22079fd5587f98ebc18da3c463d?tab=readme-ov-file#package-format) and [checked](https://github.com/typst/packages/blob/8b9e4ca98f75a22079fd5587f98ebc18da3c463d/bundler/src/main.rs#L240C1-L253C6) by the package repository.