### PR TITLE
check-case: allow all-uppercase function parameters

### DIFF
--- a/src/check/kebab_case.rs
+++ b/src/check/kebab_case.rs
@@ -104,7 +104,10 @@ fn check_source(
                     _ => continue,
                 };
 
-                if name != casbab::kebab(name) {
+                // We recommend kebab-style names but do not warn on
+                // all-uppercase names that may represent real-world
+                // acronyms.
+                if name != casbab::kebab(name) && name != casbab::screaming(name) {
                     diags.emit(Diagnostic {
                         severity: Severity::Warning,
                         message: "This argument seems to be part of public function. \


### PR DESCRIPTION
All-uppercase names may come from real-world acronyms of the package problem domain (for example "SSN" could be a plausible parameter name for a social-security number in an administrative form).

This feature idea comes from observing style warnings on my own package, which uses AAPG and CES as template parameter names -- see https://github.com/typst/packages/pull/1991#issuecomment-2719334712 . I checked that package-check does not warn about them anymore with this patch applied.