### PR TITLE
fix: Install additional runtime dependencies for GitLab CI

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
               caCertificates
               pkgs.git
               pkgs.bashNonInteractive
+              pkgs.busybox
               typst-package-check
             ];
             config = {

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
             tag = typst-package-check.version;
             copyToRoot = with pkgs.dockerTools; [
               caCertificates
-              pkgs.git
+              pkgs.gitMinimal
               pkgs.bashNonInteractive
               pkgs.busybox
               typst-package-check


### PR DESCRIPTION
to ensure the GitLab CI setup code can instantiate the runner properly.

This is a follow-up to #32 where I initially asked for a shell to become part of the Container image. It turns out my assumption about a shell being enough was wrong, there are additional runtime dependencies. I was kind of embarrassed once I had noticed but I didn't want to bother you again. So instead today I'm presenting an actual fix. Sorry for the noise!

My personal research says GitLab CI requires `mkdir` and `grep`, too. [The GitLab docs][1] only mention a shell and `mkdir`, so I've [raised an issue with GitLab][2] to look into this in greater detail. This time I have built the images locally and [verified they work][3] so no more surprises here.

[1]: https://docs.gitlab.com/18.4/ci/docker/using_docker_images/#image-requirements
[2]: https://gitlab.com/gitlab-org/gitlab/-/issues/571687
[3]: https://gitlab.com/hartang/typst/testyfy/-/jobs/11451470322