### PR TITLE
feat: Call git with tracing only

### DIFF
--- a/src/check/authors.rs
+++ b/src/check/authors.rs
@@ -38,8 +38,8 @@ pub async fn authors_are_differents(spec: &PackageSpec) -> Option<bool> {
     let repo = git::repo_dir();
     let repo = git::GitRepo::open(&repo).await.ok()?;
 
-    let last_authors = repo.authors_of(&last_manifest)?;
-    let new_authors = repo.authors_of(&new_manifest)?;
+    let last_authors = repo.authors_of(&last_manifest).await?;
+    let new_authors = repo.authors_of(&new_manifest).await?;
     Some(
         !last_authors.is_empty()
             && !new_authors.is_empty()

--- a/src/github/git.rs
+++ b/src/github/git.rs
@@ -58,24 +58,21 @@ impl<'a> GitRepo<'a> {
         Ok(parse_diff_tree_paths(&command_output))
     }
 
-    pub fn authors_of(&self, file: &Path) -> Option<HashSet<String>> {
-        use std::process::Command;
-
+    pub async fn authors_of(&self, file: &Path) -> Option<HashSet<String>> {
         debug!("Listing authors of {}", file.display());
 
         let output = String::from_utf8(
-            Command::new("git")
-                .args([
-                    "-C",
-                    self.dir.to_str()?,
-                    "blame",
-                    "--porcelain",
-                    "--",
-                    Path::new(".").canonicalize().ok()?.join(file).to_str()?,
-                ])
-                .output()
-                .ok()?
-                .stdout,
+            traced_git([
+                "-C",
+                self.dir.to_str()?,
+                "blame",
+                "--porcelain",
+                "--",
+                Path::new(".").canonicalize().ok()?.join(file).to_str()?,
+            ])
+            .await
+            .ok()?
+            .stdout,
         )
         .ok()?;
 


### PR DESCRIPTION
Replace all calls of `Command::new("git")` with the `traced_git` function. This has multiple benefits:

1. As far as I can tell, all calls to external `git` are now traced, meaning their outputs will show up in the debug log. This makes debugging and catching errors easier.
2. The functions where previously `Command::new("git")` was used are now async, integrating seamlessly with the rest of the codebase.

