### PR TITLE
fix: Update typst version output to match dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1.37.0", features = ["rt-multi-thread", "process", "fs", "m
 toml_edit = "0.23"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter"] }
+# NOTE: Update this along with the output of `Commands::TypstVersion`
 typst = "0.14.0"
 typst-assets = { version = "0.14.0", features = [ "fonts" ] }
 typst-eval = "0.14.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ async fn main() {
             }
         }
         Commands::TypstVersion => {
-            println!("0.13.1")
+            println!("0.14.0")
         }
         Commands::Action => action::main().await,
     }


### PR DESCRIPTION
since they diverged in 10ba54f6 when the `typst` dependencies were updated. Now they are back in sync.

I've been thinking about how to solve this long-term. I'm posting an issue to the `typst` main repo soon with a proposal to expose the typst version from the library to rust package authors.