### PR TITLE
Check readme file links and image alt text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4111,6 +4111,7 @@ dependencies = [
  "typst",
  "typst-assets",
  "typst-eval",
+ "url",
  "wasm-opt",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,6 +1342,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever",
+]
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,6 +2036,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.38.0+unofficial"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333171ccdf66e915257740d44e38ea5b1b19ce7b45d33cc35cb6f118fbd981ff"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "xml5ever",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2141,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2361,6 +2400,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
 name = "phf_generator"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2517,6 +2566,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "primeorder"
@@ -2680,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3201,6 +3256,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3370,6 +3450,16 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
 ]
 
 [[package]]
@@ -4003,10 +4093,13 @@ dependencies = [
  "dirs",
  "dotenvy",
  "fontdb",
+ "html5ever",
  "ignore",
  "jwt-simple",
+ "markup5ever_rcdom",
  "parking_lot",
  "pathdiff",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -4285,6 +4378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4509,6 +4608,18 @@ checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -4811,6 +4922,16 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "xml5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
+dependencies = [
+ "log",
+ "markup5ever",
+]
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,5 @@ tracing-subscriber = { version = "0.3.22", features = ["json", "env-filter"] }
 typst = "0.14.2"
 typst-assets = { version = "0.14.2", features = [ "fonts" ] }
 typst-eval = "0.14.2"
+url = "2.5.7"
 wasm-opt = "0.116.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,15 @@ comrak = { version = "0.49.0", default-features = false }
 dirs = "6.0.0"
 dotenvy = "0.15.7"
 fontdb = "0.23.0"
+html5ever = "0.38.0"
+markup5ever_rcdom = "0.38.0"
 ignore = "0.4.25"
 jwt-simple = { version = "0.12", default-features = false, features = [
     "pure-rust",
 ] }
 parking_lot = "0.12.5"
 pathdiff = "0.2.3"
+regex = "1.12.3"
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/check/files.rs
+++ b/src/check/files.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use ignore::overrides::Override;
@@ -68,4 +68,18 @@ pub fn forbid_font_files(
     }
 
     Ok(())
+}
+
+/// Stips any any leading root components (`/` or `\`) of the path before
+/// joining it to the `root` path.
+///
+/// Absolute paths (starting with `/` or `\`) replace the complete path when
+/// `join`ed with a parent path.
+pub fn path_relative_to(root: &Path, path: &Path) -> PathBuf {
+    let components = path
+        .components()
+        .skip_while(|c| matches!(c, Component::RootDir))
+        .map(|c| Path::new(c.as_os_str()));
+
+    PathBuf::from_iter(std::iter::once(root).chain(components))
 }

--- a/src/check/readme.rs
+++ b/src/check/readme.rs
@@ -1,13 +1,19 @@
+use std::io::Cursor;
+use std::path::Path;
+use std::sync::LazyLock;
 use std::{collections::HashSet, ops::Range};
 
-use codespan_reporting::diagnostic::{Diagnostic, Label};
-use comrak::nodes::{Ast as MdAst, NodeList, NodeValue as MdNode, Sourcepos};
+use codespan_reporting::diagnostic::{Diagnostic, Label, Severity};
+use comrak::nodes::{LineColumn, NodeList, NodeValue as MdNode, Sourcepos};
+use html5ever::tendril::TendrilSink;
+use regex::Regex;
 use typst::{
     foundations::Bytes,
     syntax::{FileId, VirtualPath},
     World,
 };
 
+use crate::check::files;
 use crate::{
     check::{imports, kebab_case, label, Diagnostics, TryExt},
     world::SystemWorld,
@@ -47,126 +53,286 @@ pub async fn check_readme(
     );
 
     for node in md_ast.descendants() {
-        // It is important to create a fake ID for each node, this allows to
-        // have multiple sources with the same file path, which is usefull here
-        // since the README can contain multiple Typst example blocks.
-        let readme_id = FileId::new_fake(VirtualPath::new("README.md"));
-
-        // Check that alert blocks are not used
-        if let MdAst {
-            sourcepos,
-            value: MdNode::Alert(_),
-            ..
-        } = *node.data.borrow()
-        {
-            diags.emit(
-                Diagnostic::warning()
-                    .with_code("readme/unsupported-extension/alert")
-                    .with_message("GFM alert boxes are not supported on Typst Universe.")
-                    .with_labels(vec![Label::primary(
-                        readme_id,
-                        sourcepos_to_range(&readme, &sourcepos),
-                    )]),
-            );
-            continue;
-        }
-
-        // Also check for checklists
-        if let MdAst {
-            sourcepos,
-            value: MdNode::List(NodeList {
+        let md_node = &*node.data.borrow();
+        match &md_node.value {
+            // Check that alert blocks are not used
+            MdNode::Alert(_) => {
+                diags.emit(
+                    Diagnostic::warning()
+                        .with_code("readme/unsupported-extension/alert")
+                        .with_message("GFM alert boxes are not supported on Typst Universe.")
+                        .with_labels(vec![Label::primary(
+                            readme_fake_file_id(),
+                            sourcepos_to_range(&readme, md_node.sourcepos),
+                        )]),
+                );
+            }
+            // Also check for checklists
+            MdNode::List(NodeList {
                 is_task_list: true, ..
-            }),
-            ..
-        } = *node.data.borrow()
-        {
-            diags.emit(
-                Diagnostic::warning()
-                    .with_code("readme/unsupported-extension/tasklist")
-                    .with_message("GFM task lists are not supported on Typst Universe.")
-                    .with_labels(vec![Label::primary(
-                        readme_id,
-                        sourcepos_to_range(&readme, &sourcepos),
-                    )]),
-            );
-            continue;
+            }) => {
+                diags.emit(
+                    Diagnostic::warning()
+                        .with_code("readme/unsupported-extension/tasklist")
+                        .with_message("GFM task lists are not supported on Typst Universe.")
+                        .with_label(Label::primary(
+                            readme_fake_file_id(),
+                            sourcepos_to_range(&readme, md_node.sourcepos),
+                        )),
+                );
+            }
+            // Basic Typst examples linting
+            MdNode::CodeBlock(code_block) => {
+                check_readme_code_block(world, diags, code_block, md_node.sourcepos);
+            }
+            // Check if all links are valid.
+            MdNode::Link(link) => {
+                check_readme_link_url(world, diags, &readme, md_node.sourcepos, &link.url);
+            }
+            // Check all image URLs are valid and alt text is specified.
+            MdNode::Image(link) => {
+                // The alternative description is stored a text child node.
+                let mut alt = String::new();
+                for child in node.descendants() {
+                    if let Some(text) = child.data().value.text() {
+                        alt.push_str(text);
+                    }
+                }
+                check_image_alternative_description(diags, &readme, md_node.sourcepos, &alt);
+
+                check_readme_link_url(world, diags, &readme, md_node.sourcepos, &link.url);
+            }
+            MdNode::HtmlBlock(html) => {
+                check_readme_html(world, diags, &readme, md_node.sourcepos, &html.literal);
+            }
+            MdNode::HtmlInline(html) => {
+                check_readme_html(world, diags, &readme, md_node.sourcepos, html);
+            }
+            _ => (),
         }
-
-        // Basic Typst examples linting
-        let comrak::nodes::NodeValue::CodeBlock(ref code_block) = node.data.borrow().value else {
-            continue;
-        };
-
-        let lang = code_block.info.to_lowercase();
-        if !lang.is_empty() && lang != "typ" && lang != "typst" {
-            continue;
-        }
-
-        let source = world
-            .virtual_source(
-                readme_id,
-                Bytes::from_string(code_block.literal.clone()),
-                node.data.borrow().sourcepos.start.line,
-            )
-            .unwrap();
-        for err in source.root().errors() {
-            diags.emit(
-                Diagnostic::warning()
-                    .with_code("readme/syntax")
-                    .with_message(format!(
-                        "Syntax error in README.\n\n  {}\n\n\
-                        If this code block is not supposed to be parsed as a Typst source, \
-                        please explicitely specify another language.",
-                        err.message
-                    ))
-                    .with_labels(label(world, err.span).into_iter().collect()),
-            );
-        }
-
-        kebab_case::check_ast(world, diags, &HashSet::new(), source.root(), true);
-
-        let main_path = world
-            .root()
-            .join(world.main().vpath().as_rootless_path())
-            .canonicalize()
-            .ok();
-        let all_packages = world
-            .root()
-            .parent()
-            .and_then(|package_dir| package_dir.parent())
-            .and_then(|namespace_dir| namespace_dir.parent());
-        imports::check_ast(
-            diags,
-            world,
-            source.root(),
-            &world.root().join("README.md"),
-            main_path.as_deref(),
-            all_packages,
-        );
     }
 
     Ok(())
 }
 
-fn sourcepos_to_range(s: &str, pos: &Sourcepos) -> Range<usize> {
-    fn line_start(s: &str, line: usize) -> usize {
-        let mut offset = 0;
-        // Sourcepos::line is one-indexed, enumerate is zero-indexed
-        let line = line - 1;
-
-        for (i, line_len) in s.lines().map(str::len).enumerate() {
-            if i == line {
-                return offset;
-            }
-
-            // Extra character for the \n
-            offset += line_len + 1;
-        }
-
-        offset
+fn check_readme_code_block(
+    world: &SystemWorld,
+    diags: &mut Diagnostics,
+    code_block: &comrak::nodes::NodeCodeBlock,
+    sourcepos: Sourcepos,
+) {
+    let lang = code_block.info.to_lowercase();
+    if !lang.is_empty() && lang != "typ" && lang != "typst" {
+        return;
     }
 
-    let start = line_start(s, pos.start.line) + pos.start.column - 1;
-    let end = line_start(s, pos.end.line) + pos.end.column - 1;
+    let source = world
+        .virtual_source(
+            readme_fake_file_id(),
+            Bytes::from_string(code_block.literal.clone()),
+            sourcepos.start.line,
+        )
+        .unwrap();
+    for err in source.root().errors() {
+        diags.emit(
+            Diagnostic::warning()
+                .with_code("readme/syntax")
+                .with_message(format!(
+                    "Syntax error in README.\n\n  {}\n\n\
+                        If this code block is not supposed to be parsed as a Typst source, \
+                        please explicitely specify another language.",
+                    err.message
+                ))
+                .with_labels(label(world, err.span).into_iter().collect()),
+        );
+    }
+
+    kebab_case::check_ast(world, diags, &HashSet::new(), source.root(), true);
+
+    let main_path = world
+        .root()
+        .join(world.main().vpath().as_rootless_path())
+        .canonicalize()
+        .ok();
+    let all_packages = world
+        .root()
+        .parent()
+        .and_then(|package_dir| package_dir.parent())
+        .and_then(|namespace_dir| namespace_dir.parent());
+    imports::check_ast(
+        diags,
+        world,
+        source.root(),
+        &world.root().join("README.md"),
+        main_path.as_deref(),
+        all_packages,
+    );
+}
+
+fn check_readme_html(
+    world: &SystemWorld,
+    diags: &mut Diagnostics,
+    readme: &str,
+    sourcepos: Sourcepos,
+    html: &str,
+) {
+    let parser = html5ever::parse_fragment(
+        markup5ever_rcdom::RcDom::default(),
+        html5ever::ParseOpts::default(),
+        html5ever::QualName::new(
+            Some(html5ever::Prefix::from("")),
+            html5ever::Namespace::from(""),
+            html5ever::LocalName::from(""),
+        ),
+        Vec::new(),
+        false,
+    );
+
+    let dom = parser
+        .from_utf8()
+        .read_from(&mut Cursor::new(html.as_bytes()))
+        .expect("read_from only returns IO errors, which shouldn't happen for Cursor");
+
+    check_html_elems(world, diags, readme, sourcepos, &dom.document);
+}
+
+fn check_html_elems(
+    world: &SystemWorld,
+    diags: &mut Diagnostics,
+    readme: &str,
+    sourcepos: Sourcepos,
+    node: &markup5ever_rcdom::Node,
+) {
+    for child in node.children.borrow().iter() {
+        if let markup5ever_rcdom::NodeData::Element { name, attrs, .. } = &child.data {
+            // Check images
+            if &name.local == "img" {
+                let attrs = attrs.borrow();
+
+                let alt = attr_value(&attrs, "alt").unwrap_or("");
+                check_image_alternative_description(diags, readme, sourcepos, alt);
+
+                if let Some(src) = attr_value(&attrs, "src") {
+                    check_readme_link_url(world, diags, readme, sourcepos, src);
+                }
+            }
+
+            // Check anchor elements.
+            if &name.local == "a" {
+                let attrs = attrs.borrow();
+
+                if let Some(href) = attr_value(&attrs, "href") {
+                    check_readme_link_url(world, diags, readme, sourcepos, href);
+                }
+            }
+        }
+
+        check_html_elems(world, diags, readme, sourcepos, child);
+    }
+
+    fn attr_value<'a>(attrs: &'a [html5ever::Attribute], name: &str) -> Option<&'a str> {
+        let attr = attrs.iter().find(|a| &a.name.local == name)?;
+        Some(&*attr.value)
+    }
+}
+
+fn check_readme_link_url(
+    world: &SystemWorld,
+    diags: &mut Diagnostics,
+    readme: &str,
+    sourcepos: Sourcepos,
+    url: &str,
+) {
+    let url = url.trim();
+
+    if url.contains("://") {
+        // TODO: Should we check the URL here like for the `homepage` and
+        // `repository` manifest fields?
+    } else if url.starts_with("#") {
+        // TODO: Validate markdown anchor.
+    } else {
+        // Assume this URL is a path of a local file.
+        if !files::path_relative_to(world.root(), Path::new(url)).exists() {
+            diags.emit(
+                Diagnostic::error()
+                    .with_code("readme/link/file-not-found")
+                    .with_message(format_args!(
+                        "Linked file not found: `{url}`. Make sure to commit all linked files, \
+                        and possibly add them to the `exclude` list. \
+                        More details: https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude",
+                    ))
+                    .with_labels(vec![Label::primary(
+                        readme_fake_file_id(),
+                        sourcepos_to_range(readme, sourcepos),
+                    )]),
+            );
+        }
+    }
+}
+
+fn check_image_alternative_description(
+    diags: &mut Diagnostics,
+    readme: &str,
+    sourcepos: Sourcepos,
+    alt: &str,
+) {
+    // Don't use `\w` because that would also include Chinese or similar
+    // character categories, which don't use whitespace to separate words.
+    static SINGLE_WORD: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^[\p{Cased_Letter}\p{Number}\-_]+\w$").unwrap());
+    static SINGLE_LETTER: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\w$").unwrap());
+
+    let alt = alt.trim();
+
+    if alt.is_empty() || SINGLE_WORD.is_match(alt) || SINGLE_LETTER.is_match(alt) {
+        let (severity, message) = if alt.is_empty() {
+            let message = String::from(
+                "Missing alternative description for image. \
+                 Please add a short description to make this image more accessible.",
+            );
+            (Severity::Error, message)
+        } else {
+            let message = format!(
+                "Possibly inadequate alternative description for image: `{alt}`. \
+                 Please add a short description to make this image more accessible.",
+            );
+            (Severity::Warning, message)
+        };
+        diags.emit(
+            Diagnostic::new(severity)
+                .with_code("readme/image/missing-alt")
+                .with_message(message)
+                .with_label(Label::primary(
+                    readme_fake_file_id(),
+                    sourcepos_to_range(readme, sourcepos),
+                )),
+        );
+    }
+}
+
+fn sourcepos_to_range(s: &str, pos: Sourcepos) -> Range<usize> {
+    fn byte_offset(s: &str, pos: LineColumn) -> usize {
+        // `LineColumn` uses 1-indexed line numbers.
+        let line_offset = s
+            .split_inclusive('\n')
+            .take(pos.line - 1)
+            .map(str::len)
+            .sum::<usize>();
+
+        line_offset + pos.column
+    }
+
+    // `LineColumn::column` is 1-indexed.
+    let start = byte_offset(s, pos.start) - 1;
+    // `Sourcepos::end` is end-inclusive (byte-wise), and thus `offset + 1 - 1`.
+    let end = byte_offset(s, pos.end);
+
     start..end
+}
+
+/// It is important to create a fake ID for each node, this allows to
+/// have multiple sources with the same file path, which is useful here
+/// since the README can contain multiple Typst example blocks.
+fn readme_fake_file_id() -> FileId {
+    FileId::new_fake(VirtualPath::new("README.md"))
 }

--- a/src/check/readme.rs
+++ b/src/check/readme.rs
@@ -248,6 +248,8 @@ fn check_readme_link_url(
     if url.contains("://") {
         // TODO: Should we check the URL here like for the `homepage` and
         // `repository` manifest fields?
+
+        check_repo_file_url(diags, readme, sourcepos, url);
     } else if url.starts_with("#") {
         // TODO: Validate markdown anchor.
     } else {
@@ -257,9 +259,9 @@ fn check_readme_link_url(
                 Diagnostic::error()
                     .with_code("readme/link/file-not-found")
                     .with_message(format_args!(
-                        "Linked file not found: `{url}`. Make sure to commit all linked files, \
-                        and possibly add them to the `exclude` list. \
-                        More details: https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude",
+                        "Linked file not found: `{url}`.\n\n\
+                         Make sure to commit all linked files and possibly add them to the `exclude` list.\n\n\
+                         More details: https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude",
                     ))
                     .with_labels(vec![Label::primary(
                         readme_fake_file_id(),
@@ -268,6 +270,89 @@ fn check_readme_link_url(
             );
         }
     }
+}
+
+const DEFAULT_BRANCHES: [&str; 2] = ["main", "master"];
+
+fn check_repo_file_url(
+    diags: &mut Diagnostics,
+    readme: &str,
+    sourcepos: Sourcepos,
+    url: &str,
+) -> Option<()> {
+    static GITHUB_URL: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"https://github.com/([^/]+)/([^/]+)/(?:blob|tree)/([^/]+)/(.+)").unwrap()
+    });
+    static GITHUB_RAW_URL: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"^https://raw.githubusercontent.com/([^/]+)/([^/]+)/(?:refs/heads/)?([^/]+)/(.+)$",
+        )
+        .unwrap()
+    });
+    static GITLAB_URL: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"https://gitlab.com/([^/]+)/([^/]+)/-/(?:raw|blob|tree)/([^/]+)/(.+)").unwrap()
+    });
+    static CODEBERG_URL: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"https://codeberg.org/([^/]+)/([^/]+)/(?:raw|src)/branch/([^/]+)/(.+)").unwrap()
+    });
+
+    enum Host {
+        Github,
+        Gitlab,
+        Codeberg,
+    }
+
+    let (host, captures) = if let Some(captures) =
+        (GITHUB_URL.captures(url)).or_else(|| GITHUB_RAW_URL.captures(url))
+    {
+        (Host::Github, captures)
+    } else if let Some(captures) = GITLAB_URL.captures(url) {
+        (Host::Gitlab, captures)
+    } else if let Some(captures) = CODEBERG_URL.captures(url) {
+        (Host::Codeberg, captures)
+    } else {
+        return None;
+    };
+
+    let user = captures.get(1).unwrap().as_str();
+    let repo = captures.get(2).unwrap().as_str();
+    let branch = captures.get(3).unwrap().as_str();
+    let path = captures.get(4).unwrap().as_str();
+
+    if !DEFAULT_BRANCHES.contains(&branch) {
+        return None;
+    }
+
+    let name = match host {
+        Host::Github => "GitHub",
+        Host::Gitlab => "Gitlab",
+        Host::Codeberg => "Codeberg",
+    };
+
+    let non_raw_url = match host {
+        Host::Github => format!("https://github.com/{user}/{repo}/blob/{branch}/{path}"),
+        Host::Gitlab => format!("https://gitlab.com/{user}/{repo}/-/blob/{branch}/{path}"),
+        Host::Codeberg => format!("https://codeberg.org/{user}/{repo}/src/branch/{branch}/{path}"),
+    };
+
+    diags.emit(
+        Diagnostic::warning()
+            .with_code("readme/link/github-url-permalink")
+            .with_message(format_args!(
+                "{name} URL links to default branch: `{url}`.\n\n\
+                 Consider using a link to a specific tag/release or a permalink to a commit instead. \
+                 This will ensure that the linked resource always matches this version of the package.\n\n\
+                 You can create a permalink here: {non_raw_url}\n\n\
+                 Alternatively you can also link to a local file. This is preferred if the linked file \
+                 is already present in the submitted package."
+            ))
+            .with_label(Label::primary(
+                readme_fake_file_id(),
+                sourcepos_to_range(readme, sourcepos),
+            )),
+    );
+
+    Some(())
 }
 
 fn check_image_alternative_description(

--- a/src/check/readme.rs
+++ b/src/check/readme.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::sync::LazyLock;
 use std::{collections::HashSet, ops::Range};
 
-use codespan_reporting::diagnostic::{Diagnostic, Label, Severity};
+use codespan_reporting::diagnostic::{Diagnostic, Label};
 use comrak::nodes::{LineColumn, NodeList, NodeValue as MdNode, Sourcepos};
 use html5ever::tendril::TendrilSink;
 use regex::Regex;
@@ -62,7 +62,7 @@ pub async fn check_readme(
                         .with_code("readme/unsupported-extension/alert")
                         .with_message("GFM alert boxes are not supported on Typst Universe.")
                         .with_labels(vec![Label::primary(
-                            readme_fake_file_id(),
+                            readme_file_id(),
                             sourcepos_to_range(&readme, md_node.sourcepos),
                         )]),
                 );
@@ -76,7 +76,7 @@ pub async fn check_readme(
                         .with_code("readme/unsupported-extension/tasklist")
                         .with_message("GFM task lists are not supported on Typst Universe.")
                         .with_label(Label::primary(
-                            readme_fake_file_id(),
+                            readme_file_id(),
                             sourcepos_to_range(&readme, md_node.sourcepos),
                         )),
                 );
@@ -126,9 +126,13 @@ fn check_readme_code_block(
         return;
     }
 
+    // It is important to create a fake ID for each markdown code block. This
+    // allows having multiple sources with the same file path, since the README
+    // can contain multiple Typst example blocks.
+    let readme_code_block_id = FileId::new_fake(VirtualPath::new("README.md"));
     let source = world
         .virtual_source(
-            readme_fake_file_id(),
+            readme_code_block_id,
             Bytes::from_string(code_block.literal.clone()),
             sourcepos.start.line,
         )
@@ -264,7 +268,7 @@ fn check_readme_link_url(
                          More details: https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude",
                     ))
                     .with_labels(vec![Label::primary(
-                        readme_fake_file_id(),
+                        readme_file_id(),
                         sourcepos_to_range(readme, sourcepos),
                     )]),
             );
@@ -274,12 +278,7 @@ fn check_readme_link_url(
 
 const DEFAULT_BRANCHES: [&str; 2] = ["main", "master"];
 
-fn check_repo_file_url(
-    diags: &mut Diagnostics,
-    readme: &str,
-    sourcepos: Sourcepos,
-    url: &str,
-) -> Option<()> {
+fn check_repo_file_url(diags: &mut Diagnostics, readme: &str, sourcepos: Sourcepos, url: &str) {
     static GITHUB_URL: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"https://github.com/([^/]+)/([^/]+)/(?:blob|tree)/([^/]+)/(.+)").unwrap()
     });
@@ -311,7 +310,7 @@ fn check_repo_file_url(
     } else if let Some(captures) = CODEBERG_URL.captures(url) {
         (Host::Codeberg, captures)
     } else {
-        return None;
+        return;
     };
 
     let user = captures.get(1).unwrap().as_str();
@@ -320,7 +319,7 @@ fn check_repo_file_url(
     let path = captures.get(4).unwrap().as_str();
 
     if !DEFAULT_BRANCHES.contains(&branch) {
-        return None;
+        return;
     }
 
     let name = match host {
@@ -337,7 +336,7 @@ fn check_repo_file_url(
 
     diags.emit(
         Diagnostic::warning()
-            .with_code("readme/link/github-url-permalink")
+            .with_code("readme/link/repository-url-permalink")
             .with_message(format_args!(
                 "{name} URL links to default branch: `{url}`.\n\n\
                  Consider using a link to a specific tag/release or a permalink to a commit instead. \
@@ -347,12 +346,10 @@ fn check_repo_file_url(
                  is already present in the submitted package."
             ))
             .with_label(Label::primary(
-                readme_fake_file_id(),
+                readme_file_id(),
                 sourcepos_to_range(readme, sourcepos),
             )),
     );
-
-    Some(())
 }
 
 fn check_image_alternative_description(
@@ -368,27 +365,29 @@ fn check_image_alternative_description(
     static SINGLE_LETTER: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\w$").unwrap());
 
     let alt = alt.trim();
-
-    if alt.is_empty() || SINGLE_WORD.is_match(alt) || SINGLE_LETTER.is_match(alt) {
-        let (severity, message) = if alt.is_empty() {
-            let message = String::from(
-                "Missing alternative description for image. \
-                 Please add a short description to make this image more accessible.",
-            );
-            (Severity::Error, message)
-        } else {
-            let message = format!(
-                "Possibly inadequate alternative description for image: `{alt}`. \
-                 Please add a short description to make this image more accessible.",
-            );
-            (Severity::Warning, message)
-        };
+    if alt.is_empty() {
         diags.emit(
-            Diagnostic::new(severity)
+            Diagnostic::error()
                 .with_code("readme/image/missing-alt")
-                .with_message(message)
+                .with_message(
+                    "Missing alternative description for image. \
+                     Please add a short description to make this image more accessible.",
+                )
                 .with_label(Label::primary(
-                    readme_fake_file_id(),
+                    readme_file_id(),
+                    sourcepos_to_range(readme, sourcepos),
+                )),
+        );
+    } else if SINGLE_WORD.is_match(alt) || SINGLE_LETTER.is_match(alt) {
+        diags.emit(
+            Diagnostic::warning()
+                .with_code("readme/image/inadequate-alt")
+                .with_message(format_args!(
+                    "Possibly inadequate alternative description for image: `{alt}`. \
+                     Please add a short description to make this image more accessible."
+                ))
+                .with_label(Label::primary(
+                    readme_file_id(),
                     sourcepos_to_range(readme, sourcepos),
                 )),
         );
@@ -415,9 +414,6 @@ fn sourcepos_to_range(s: &str, pos: Sourcepos) -> Range<usize> {
     start..end
 }
 
-/// It is important to create a fake ID for each node, this allows to
-/// have multiple sources with the same file path, which is useful here
-/// since the README can contain multiple Typst example blocks.
-fn readme_fake_file_id() -> FileId {
-    FileId::new_fake(VirtualPath::new("README.md"))
+fn readme_file_id() -> FileId {
+    FileId::new(None, VirtualPath::new("README.md"))
 }

--- a/src/check/readme.rs
+++ b/src/check/readme.rs
@@ -12,6 +12,7 @@ use typst::{
     syntax::{FileId, VirtualPath},
     World,
 };
+use url::Url;
 
 use crate::check::files;
 use crate::{
@@ -245,34 +246,69 @@ fn check_readme_link_url(
     diags: &mut Diagnostics,
     readme: &str,
     sourcepos: Sourcepos,
-    url: &str,
+    url_text: &str,
 ) {
-    let url = url.trim();
+    let url_text = url_text.trim();
 
-    if url.contains("://") {
-        // TODO: Should we check the URL here like for the `homepage` and
-        // `repository` manifest fields?
+    // Allow links that are only fragments: `#readme-section`.
+    if url_text.starts_with("#") {
+        // TODO: Consider validating that the fragment is valid.
+        return;
+    }
 
-        check_repo_file_url(diags, readme, sourcepos, url);
-    } else if url.starts_with("#") {
-        // TODO: Validate markdown anchor.
-    } else {
-        // Assume this URL is a path of a local file.
-        if !files::path_relative_to(world.root(), Path::new(url)).exists() {
-            diags.emit(
-                Diagnostic::error()
-                    .with_code("readme/link/file-not-found")
-                    .with_message(format_args!(
-                        "Linked file not found: `{url}`.\n\n\
-                         Make sure to commit all linked files and possibly add them to the `exclude` list.\n\n\
-                         More details: https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude",
-                    ))
-                    .with_labels(vec![Label::primary(
-                        readme_file_id(),
-                        sourcepos_to_range(readme, sourcepos),
-                    )]),
-            );
+    let url_error = match Url::parse(url_text) {
+        Ok(url) => {
+            // TODO: Should we check the URL here like for the `homepage` and
+            // `repository` manifest fields?
+
+            check_repo_file_url(diags, readme, sourcepos, url.as_str());
+
+            return;
         }
+        Err(error) => error,
+    };
+
+    let invalid_url_error = || {
+        Diagnostic::error()
+            .with_code("readme/link/invalid-url")
+            .with_message(format_args!("Invalid url: `{url_text}`\n{url_error}"))
+            .with_labels(vec![Label::primary(
+                readme_file_id(),
+                sourcepos_to_range(readme, sourcepos),
+            )])
+    };
+
+    // The link couldn't be parsed as a URL, assume it's a local file.
+    let file_url = format!("file:///{url_text}");
+    let Ok(url) = Url::parse(&file_url) else {
+        diags.emit(invalid_url_error());
+        return;
+    };
+
+    // Don't allow URL with empty paths. If the path consists only of the root
+    // component that we added above, the path was completely empty before.
+    let absolute_path = url.path();
+    if absolute_path == "/" {
+        diags.emit(invalid_url_error());
+        return;
+    }
+
+    // Check if the local file exists.
+    if !files::path_relative_to(world.root(), Path::new(absolute_path)).exists() {
+        diags.emit(
+            Diagnostic::error()
+                .with_code("readme/link/file-not-found")
+                .with_message(format_args!(
+                    "Linked file not found: `{absolute_path}`.\n\n\
+                     Make sure to commit all linked files and possibly add them to the `exclude` list.\n\n\
+                     More details: https://github.com/typst/packages/blob/main/docs/tips.md#what-to-commit-what-to-exclude",
+                ))
+                .with_note(format_args!("This link was assumed to be a local file because it's couldn't be parsed as an URL: `{url_text}`\n{url_error}"))
+                .with_labels(vec![Label::primary(
+                    readme_file_id(),
+                    sourcepos_to_range(readme, sourcepos),
+                )]),
+        );
     }
 }
 


### PR DESCRIPTION
Closes #47, #48 and #51 

This implements a few checks for readme links and images.

1. Generate an error for any markdown/HTML links and images that link to local files, which are missing.
2. Generate a warning for file links to the default branch on GitHub, Gitlab, or Codeberg.
3. Check if the alternative-description of a readme image is missing or possibly inadequate.