### PR TITLE
Refactors and warning for unlinked manuals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,6 +4105,7 @@ dependencies = [
  "typst-assets",
  "typst-eval",
  "url",
+ "walkdir",
  "wasm-opt",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,5 @@ typst = "0.14.2"
 typst-assets = { version = "0.14.2", features = [ "fonts" ] }
 typst-eval = "0.14.2"
 url = "2.5.7"
+walkdir = "2.5.0"
 wasm-opt = "0.116.1"

--- a/src/check.rs
+++ b/src/check.rs
@@ -6,10 +6,8 @@ use typst::{
     WorldExt,
 };
 
-use crate::{
-    check::{files::forbid_font_files, readme::check_readme},
-    world::SystemWorld,
-};
+use crate::check::readme::check_readme;
+use crate::world::SystemWorld;
 
 pub mod authors;
 mod compile;
@@ -18,6 +16,7 @@ mod files;
 mod imports;
 mod kebab_case;
 mod manifest;
+mod path;
 mod readme;
 
 pub use diagnostics::{Diagnostics, Result, TryExt};
@@ -40,9 +39,6 @@ pub async fn all_checks(
             .expect("Template should be in a subfolder of the package");
         diags.extend(template_diags, template_dir);
     }
-
-    let res = forbid_font_files(&package_dir, &mut diags);
-    diags.maybe_emit(res);
 
     let res = check_readme(&worlds.package, &mut diags).await;
     diags.maybe_emit(res);

--- a/src/check.rs
+++ b/src/check.rs
@@ -6,7 +6,6 @@ use typst::{
     WorldExt,
 };
 
-use crate::check::readme::check_readme;
 use crate::world::SystemWorld;
 
 pub mod authors;
@@ -30,8 +29,6 @@ pub async fn all_checks(
 
     let (manifest, worlds) = manifest::check(&package_dir, &mut diags, package_spec).await?;
 
-    files::check(&mut diags, &package_dir, &manifest);
-
     compile::check(&mut diags, &worlds.package);
     if let Some(template_world) = worlds.template {
         let mut template_diags = Diagnostics::default();
@@ -43,8 +40,10 @@ pub async fn all_checks(
         diags.extend(template_diags, template_dir);
     }
 
-    let res = check_readme(&worlds.package, &mut diags).await;
-    diags.maybe_emit(res);
+    let res = readme::check(&worlds.package, &mut diags).await;
+    let readme = diags.maybe_emit(res);
+
+    files::check(&mut diags, &package_dir, &manifest, &readme);
 
     kebab_case::check(&mut diags, &worlds.package);
 

--- a/src/check.rs
+++ b/src/check.rs
@@ -28,7 +28,10 @@ pub async fn all_checks(
 ) -> Result<(SystemWorld, Diagnostics)> {
     let mut diags = Diagnostics::default();
 
-    let worlds = manifest::check(&package_dir, &mut diags, package_spec).await?;
+    let (manifest, worlds) = manifest::check(&package_dir, &mut diags, package_spec).await?;
+
+    files::check(&mut diags, &package_dir, &manifest);
+
     compile::check(&mut diags, &worlds.package);
     if let Some(template_world) = worlds.template {
         let mut template_diags = Diagnostics::default();

--- a/src/check/diagnostics.rs
+++ b/src/check/diagnostics.rs
@@ -36,9 +36,13 @@ pub struct Diagnostics {
 }
 
 impl Diagnostics {
-    pub fn maybe_emit<T>(&mut self, maybe_err: Result<T>) {
-        if let Err(e) = maybe_err {
-            self.emit(e)
+    pub fn maybe_emit<T>(&mut self, maybe_err: Result<T>) -> Option<T> {
+        match maybe_err {
+            Ok(v) => Some(v),
+            Err(e) => {
+                self.emit(e);
+                None
+            }
         }
     }
 

--- a/src/check/files.rs
+++ b/src/check/files.rs
@@ -5,9 +5,15 @@ use codespan_reporting::diagnostic::{Diagnostic, Label};
 
 use crate::check::manifest::Manifest;
 use crate::check::path::PackagePath;
+use crate::check::readme::Readme;
 use crate::check::Diagnostics;
 
-pub fn check(diags: &mut Diagnostics, package_dir: &Path, manifest: &Manifest) {
+pub fn check(
+    diags: &mut Diagnostics,
+    package_dir: &Path,
+    manifest: &Manifest,
+    readme: &Option<Readme>,
+) {
     let exclude = &manifest.package.exclude;
     let thumbnail_path = manifest.thumbnail();
 
@@ -43,6 +49,7 @@ pub fn check(diags: &mut Diagnostics, package_dir: &Path, manifest: &Manifest) {
         forbid_font_files(diags, file_path);
         exclude_large_files(diags, file_path, excluded, metadata.len());
         exclude_examples_and_tests(diags, file_path, excluded);
+        link_manuals(diags, readme, file_path, excluded);
     }
 }
 
@@ -110,10 +117,7 @@ fn exclude_large_files(
 }
 
 fn check_wasm_file_size(diags: &mut Diagnostics, path: PackagePath<&Path>, original_size: u64) {
-    let Some(file_name) = path.full().file_name() else {
-        return;
-    };
-    let out = std::env::temp_dir().join(file_name);
+    let out = std::env::temp_dir().join(path.file_name());
 
     let wasm_opt_result = wasm_opt::OptimizationOptions::new_optimize_for_size()
         // Explicitely enable and disable features to best match what wasmi supports
@@ -193,4 +197,34 @@ fn forbid_font_files(diags: &mut Diagnostics, path: PackagePath<&Path>) {
                 More details: https://github.com/typst/packages/blob/main/docs/resources.md#fonts-are-not-supported-in-packages",
             ),
     );
+}
+
+fn link_manuals(
+    diags: &mut Diagnostics,
+    readme: &Option<Readme>,
+    path: PackagePath<&Path>,
+    excluded: bool,
+) {
+    let Some(readme) = readme.as_ref() else {
+        return;
+    };
+
+    let name = path.file_name().to_string_lossy().to_lowercase();
+
+    const MANUAL_FILES: [&str; 4] = ["manual.pdf", "doc.pdf", "docs.pdf", "documentation.pdf"];
+    if MANUAL_FILES.contains(&name.as_str())
+        && readme.linked_files.iter().all(|l| l.full() != path.full())
+    {
+        let note = (!excluded)
+            .then(|| "It should also be added to `exclude` in your `typst.toml`.".into());
+
+        diags.emit(Diagnostic::warning()
+            .with_label(Label::primary(path.file_id(), 0..0))
+            .with_code("files/manual/unlinked")
+            .with_message(
+                "This file seems to be a manual/documentation, but isn't linked in the readme. \
+                 It will be inacessible on Typst Universe.",
+            )
+            .with_notes_iter(note));
+    }
 }

--- a/src/check/files.rs
+++ b/src/check/files.rs
@@ -1,85 +1,201 @@
-use std::path::{Component, Path, PathBuf};
+use std::collections::HashSet;
+use std::path::Path;
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use ignore::overrides::Override;
-use typst::syntax::{FileId, VirtualPath};
 
-use crate::check::{Diagnostics, Result, TryExt};
+use crate::check::path::PackagePath;
+use crate::check::Diagnostics;
 
-/// Size (in bytes) after which a file is considered large.
-const SIZE_THRESHOLD: u64 = 1024 * 1024; // 1 MB
-
-pub fn find_large_files(dir: &Path, exclude: Override) -> Result<Vec<(PathBuf, u64)>> {
-    let mut result = Vec::new();
-    for ch in ignore::WalkBuilder::new(dir).overrides(exclude).build() {
-        let Ok(ch) = ch else {
-            continue;
-        };
-        let Ok(metadata) = ch.metadata() else {
-            continue;
-        };
-        if metadata.is_file() && metadata.len() > SIZE_THRESHOLD {
-            result.push((
-                ch.path()
-                    .strip_prefix(dir)
-                    .error("internal", "Prefix striping failed even though child path (`ch`) was constructed from parent path (`dir`)")?
-                    .to_owned(),
-                metadata.len(),
-            ))
-        }
-    }
-    Ok(result)
-}
-
-pub fn forbid_font_files(
-    package_dir: &Path,
+pub fn check_files(
     diags: &mut Diagnostics,
-) -> std::result::Result<(), Diagnostic<FileId>> {
-    for ch in ignore::WalkBuilder::new(package_dir).build() {
-        let Ok(ch) = ch else {
-            continue;
-        };
+    package_dir: &Path,
+    exclude: &Override,
+    thumbnail_path: Option<PackagePath>,
+) {
+    let thumbnail_path = thumbnail_path.as_ref().map(PackagePath::as_path);
+
+    // Manually keep track of excluded directories, to figure out if nested
+    // files are ignored. This is done, so we can generate diagnostics for
+    // excluded files.
+    let mut excluded_dirs = HashSet::new();
+
+    for ch in ignore::WalkBuilder::new(package_dir).hidden(false).build() {
+        let Ok(ch) = ch else { continue };
         let Ok(metadata) = ch.metadata() else {
             continue;
         };
 
-        let ext = ch
-            .path()
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or_default()
-            .to_lowercase();
-        if metadata.is_file() && (&ext == "otf" || &ext == "ttf") {
-            let file_id = FileId::new(None, VirtualPath::new(ch.path().strip_prefix(package_dir)
-                    .error("internal", "Prefix striping failed even though child path (`ch`) was constructed from parent path (`dir`)")?
-        ));
-            diags.emit(
-                Diagnostic::error()
-                    .with_label(Label::primary(file_id, 0..0))
-                    .with_code("files/fonts")
-                    .with_message(
-                        "Font files are not allowed.\n\n\
-                        Delete them and instruct your users to install them manually, \
-                        in your README and/or in a documentation comment.\n\n\
-                        More details: https://github.com/typst/packages/blob/main/docs/resources.md#fonts-are-not-supported-in-packages",
-                    ),
-            );
-        }
-    }
+        let file_path = PackagePath::from_full(package_dir, ch.path());
 
-    Ok(())
+        if metadata.is_dir() {
+            // If the parent directory is ignored, all children are ignored too.
+            if parent_is_excluded(&excluded_dirs, file_path)
+                || exclude.matched(file_path.relative(), true).is_ignore()
+            {
+                excluded_dirs.insert(ch.into_path());
+            }
+            continue;
+        }
+
+        // The thumbnail is always excluded.
+        let is_thumbnail = Some(file_path) == thumbnail_path;
+        let excluded = is_thumbnail
+            || parent_is_excluded(&excluded_dirs, file_path)
+            || exclude.matched(file_path.relative(), false).is_ignore();
+
+        forbid_font_files(diags, file_path);
+
+        exclude_large_files(diags, file_path, excluded, metadata.len());
+        exclude_examples_and_tests(diags, file_path, excluded);
+    }
 }
 
-/// Stips any any leading root components (`/` or `\`) of the path before
-/// joining it to the `root` path.
-///
-/// Absolute paths (starting with `/` or `\`) replace the complete path when
-/// `join`ed with a parent path.
-pub fn path_relative_to(root: &Path, path: &Path) -> PathBuf {
-    let components = path
-        .components()
-        .skip_while(|c| matches!(c, Component::RootDir))
-        .map(|c| Path::new(c.as_os_str()));
+fn parent_is_excluded(
+    excluded_dirs: &HashSet<std::path::PathBuf>,
+    file_path: PackagePath<&Path>,
+) -> bool {
+    file_path
+        .full()
+        .parent()
+        .is_some_and(|parent| excluded_dirs.contains(parent))
+}
 
-    PathBuf::from_iter(std::iter::once(root).chain(components))
+fn exclude_large_files(
+    diags: &mut Diagnostics,
+    path: PackagePath<&Path>,
+    excluded: bool,
+    size: u64,
+) {
+    /// Size (in bytes) after which a file is considered large.
+    const LARGE: u64 = 1024 * 1024; // 1 MB
+    const REALLY_LARGE: u64 = 50 * 1024 * 1024; // 50 MB
+
+    if size < LARGE {
+        return;
+    }
+
+    if path.extension().is_some_and(|ext| ext == "wasm") {
+        check_wasm_file_size(diags, path, size);
+        // Don't suggest to exclude WASM files, they are generally necessary
+        // for the package to work.
+        return;
+    }
+
+    let (code, message) = if size > REALLY_LARGE {
+        (
+            "size/extra-large",
+            format!(
+                "This file is really large ({size}MB). \
+                 If possible, do not include it in this repository at all.",
+                size = size / 1024 / 1024
+            ),
+        )
+    } else if !excluded {
+        (
+            "size/large",
+            format!(
+                "This file is quite large ({size}MB). \
+                 If it is not required to use the package \
+                 (i.e. it is a documentation file, or part of an example), \
+                 it should be added to `exclude` in your `typst.toml`.",
+                size = size / 1024 / 1024
+            ),
+        )
+    } else {
+        return;
+    };
+
+    diags.emit(
+        Diagnostic::warning()
+            .with_code(code)
+            .with_label(Label::primary(path.file_id(), 0..0))
+            .with_message(message),
+    )
+}
+
+fn check_wasm_file_size(diags: &mut Diagnostics, path: PackagePath<&Path>, original_size: u64) {
+    let Some(file_name) = path.full().file_name() else {
+        return;
+    };
+    let out = std::env::temp_dir().join(file_name);
+
+    let wasm_opt_result = wasm_opt::OptimizationOptions::new_optimize_for_size()
+        // Explicitely enable and disable features to best match what wasmi supports
+        // https://github.com/wasmi-labs/wasmi?tab=readme-ov-file#webassembly-proposals
+        .enable_feature(wasm_opt::Feature::MutableGlobals)
+        .enable_feature(wasm_opt::Feature::TruncSat)
+        .enable_feature(wasm_opt::Feature::SignExt)
+        .enable_feature(wasm_opt::Feature::Multivalue)
+        .enable_feature(wasm_opt::Feature::BulkMemory)
+        .enable_feature(wasm_opt::Feature::ReferenceTypes)
+        .enable_feature(wasm_opt::Feature::TailCall)
+        .enable_feature(wasm_opt::Feature::ExtendedConst)
+        .enable_feature(wasm_opt::Feature::MultiMemory)
+        .enable_feature(wasm_opt::Feature::Simd)
+        .disable_feature(wasm_opt::Feature::RelaxedSimd)
+        .disable_feature(wasm_opt::Feature::Gc)
+        .disable_feature(wasm_opt::Feature::ExceptionHandling)
+        .run(path.full(), &out);
+
+    if wasm_opt_result.is_ok() {
+        if let Ok(new_size) = std::fs::metadata(&out).map(|m| m.len()) {
+            let diff = (original_size - new_size) / 1024;
+
+            if diff > 20 {
+                diags.emit(
+                    Diagnostic::warning()
+                        .with_label(Label::primary(path.file_id(), 0..0))
+                        .with_code("size/wasm")
+                        .with_message(format!(
+                            "This file could be {diff}kB smaller with `wasm-opt -Os`."
+                        )),
+                );
+            }
+        }
+
+        // TODO: ideally this should be async
+        std::fs::remove_file(out).ok();
+    }
+}
+
+fn exclude_examples_and_tests(diags: &mut Diagnostics, path: PackagePath<&Path>, excluded: bool) {
+    if excluded {
+        return;
+    }
+
+    let file_name = path.file_name().to_string_lossy();
+    let warning = || Diagnostic::warning().with_label(Label::primary(path.file_id(), 0..0));
+    if file_name.contains("example") {
+        diags.emit(warning().with_code("exclude/example").with_message(
+            "This file seems to be an example, \
+             and should probably be added to `exclude` in your `typst.toml`.",
+        ));
+    } else if file_name.contains("test") {
+        diags.emit(warning().with_code("exclude/test").with_message(
+            "This file seems to be a test, \
+             and should probably be added to `exclude` in your `typst.toml`.",
+        ));
+    }
+}
+
+fn forbid_font_files(diags: &mut Diagnostics, path: PackagePath<&Path>) {
+    let Some(ext) = path.extension() else {
+        return;
+    };
+    if !(ext == "otf" || ext == "ttf") {
+        return;
+    }
+
+    diags.emit(
+        Diagnostic::error()
+            .with_label(Label::primary(path.file_id(), 0..0))
+            .with_code("files/fonts")
+            .with_message(
+                "Font files are not allowed.\n\n\
+                Delete them and instruct your users to install them manually, \
+                in your README and/or in a documentation comment.\n\n\
+                More details: https://github.com/typst/packages/blob/main/docs/resources.md#fonts-are-not-supported-in-packages",
+            ),
+    );
 }

--- a/src/check/files.rs
+++ b/src/check/files.rs
@@ -2,18 +2,14 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
-use ignore::overrides::Override;
 
+use crate::check::manifest::Manifest;
 use crate::check::path::PackagePath;
 use crate::check::Diagnostics;
 
-pub fn check_files(
-    diags: &mut Diagnostics,
-    package_dir: &Path,
-    exclude: &Override,
-    thumbnail_path: Option<PackagePath>,
-) {
-    let thumbnail_path = thumbnail_path.as_ref().map(PackagePath::as_path);
+pub fn check(diags: &mut Diagnostics, package_dir: &Path, manifest: &Manifest) {
+    let exclude = &manifest.package.exclude;
+    let thumbnail_path = manifest.thumbnail();
 
     // Manually keep track of excluded directories, to figure out if nested
     // files are ignored. This is done, so we can generate diagnostics for
@@ -39,13 +35,12 @@ pub fn check_files(
         }
 
         // The thumbnail is always excluded.
-        let is_thumbnail = Some(file_path) == thumbnail_path;
+        let is_thumbnail = thumbnail_path.is_some_and(|t| t.val == file_path);
         let excluded = is_thumbnail
             || parent_is_excluded(&excluded_dirs, file_path)
             || exclude.matched(file_path.relative(), false).is_ignore();
 
         forbid_font_files(diags, file_path);
-
         exclude_large_files(diags, file_path, excluded, metadata.len());
         exclude_examples_and_tests(diags, file_path, excluded);
     }

--- a/src/check/imports.rs
+++ b/src/check/imports.rs
@@ -8,23 +8,16 @@ use typst::{
     syntax::{
         ast::{self, AstNode, ModuleImport},
         package::{PackageSpec, PackageVersion, VersionlessPackageSpec},
-        FileId, VirtualPath,
     },
     World,
 };
+use walkdir::WalkDir;
 
-use crate::{
-    check::{label, TryExt},
-    world::SystemWorld,
-};
-
-use super::{Diagnostics, Result};
+use crate::check::path::PackagePath;
+use crate::check::{label, Diagnostics, Result, TryExt};
+use crate::world::SystemWorld;
 
 pub fn check(diags: &mut Diagnostics, package_dir: &Path, world: &SystemWorld) -> Result<()> {
-    check_dir(diags, package_dir, world)
-}
-
-pub fn check_dir(diags: &mut Diagnostics, dir: &Path, world: &SystemWorld) -> Result<()> {
     let root_path = world.root();
     let main_path = root_path
         .join(world.main().vpath().as_rootless_path())
@@ -35,36 +28,24 @@ pub fn check_dir(diags: &mut Diagnostics, dir: &Path, world: &SystemWorld) -> Re
         .and_then(|package_dir| package_dir.parent())
         .and_then(|namespace_dir| namespace_dir.parent());
 
-    for ch in std::fs::read_dir(dir).error("internal/io", "Can't read directory")? {
-        let Ok(ch) = ch else {
-            continue;
-        };
+    for ch in WalkDir::new(package_dir).into_iter().flatten() {
         let Ok(meta) = ch.metadata() else {
             continue;
         };
-
-        let path = dir.join(ch.file_name());
-        if meta.is_dir() {
-            check_dir(diags, &path, world)?;
+        if !meta.is_file() {
+            continue;
         }
-        if path.extension().and_then(|ext| ext.to_str()) == Some("typ") {
-            let fid = FileId::new(
-                None,
-                VirtualPath::new(
-                    path.strip_prefix(root_path)
-                        // Not actually true
-                        .error(
-                            "internal",
-                            "Prefix striping failed even though `path` is built from `root_dir`",
-                        )?,
-                ),
-            );
-            let source = world.lookup(fid).error("io", "Can't read source file")?;
+
+        let path = PackagePath::from_full(package_dir, ch.path());
+        if path.extension().is_some_and(|ext| ext == "typ") {
+            let source = world
+                .lookup(path.file_id())
+                .error("io", "Can't read source file")?;
             check_ast(
                 diags,
                 world,
                 source.root(),
-                &path,
+                path.full(),
                 main_path.as_deref(),
                 all_packages,
             );

--- a/src/check/manifest.rs
+++ b/src/check/manifest.rs
@@ -1,8 +1,4 @@
-use std::{
-    ops::Range,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::{ops::Range, path::Path, str::FromStr};
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use ignore::overrides::{Override, OverrideBuilder};
@@ -14,6 +10,7 @@ use typst::syntax::{
     FileId, VirtualPath,
 };
 
+use crate::check::path::PackagePath;
 use crate::{
     check::{files, Diagnostics, Result, TryExt},
     world::SystemWorld,
@@ -112,11 +109,14 @@ pub async fn check(
         None
     };
 
-    dont_exclude_template_files(diags, &manifest, package_dir, &exclude);
+    let template_dir = template_root(package_dir, &manifest);
+
+    if let Some(template_dir) = &template_dir {
+        dont_exclude_template_files(diags, package_dir, &exclude, template_dir.as_path());
+    }
     let thumbnail_path = check_thumbnail(diags, &manifest, manifest_file_id, package_dir, &exclude);
 
-    let res = exclude_large_files(diags, package_dir, &manifest, &exclude, thumbnail_path);
-    diags.maybe_emit(res);
+    files::check_files(diags, package_dir, &exclude, thumbnail_path);
 
     Ok(Worlds {
         package: world,
@@ -297,192 +297,6 @@ fn check_compiler_version(
     }
 
     Some(())
-}
-
-fn exclude_large_files(
-    diags: &mut Diagnostics,
-    package_dir: &Path,
-    manifest: &toml_edit::Document<&String>,
-    exclude: &Override,
-    thumbnail_path: Option<PathBuf>,
-) -> Result<()> {
-    let template_dir = template_root(package_dir, manifest);
-
-    const REALLY_LARGE: u64 = 50 * 1024 * 1024;
-
-    let large_files = files::find_large_files(package_dir, exclude.clone());
-    for (path, size) in large_files? {
-        if Some(path.as_ref())
-            == thumbnail_path
-                .as_ref()
-                .and_then(|t| t.strip_prefix(package_dir).ok())
-        {
-            // Thumbnail is always excluded
-            continue;
-        }
-
-        if path.extension().and_then(|ext| ext.to_str()) == Some("wasm") {
-            let path = package_dir.join(&path);
-            if let Some(file_name) = path.file_name() {
-                let out = std::env::temp_dir().join(file_name);
-
-                let wasm_opt_result = wasm_opt::OptimizationOptions::new_optimize_for_size()
-                    // Explicitely enable and disable features to best match what wasmi supports
-                    // https://github.com/wasmi-labs/wasmi?tab=readme-ov-file#webassembly-proposals
-                    .enable_feature(wasm_opt::Feature::MutableGlobals)
-                    .enable_feature(wasm_opt::Feature::TruncSat)
-                    .enable_feature(wasm_opt::Feature::SignExt)
-                    .enable_feature(wasm_opt::Feature::Multivalue)
-                    .enable_feature(wasm_opt::Feature::BulkMemory)
-                    .enable_feature(wasm_opt::Feature::ReferenceTypes)
-                    .enable_feature(wasm_opt::Feature::TailCall)
-                    .enable_feature(wasm_opt::Feature::ExtendedConst)
-                    .enable_feature(wasm_opt::Feature::MultiMemory)
-                    .enable_feature(wasm_opt::Feature::Simd)
-                    .disable_feature(wasm_opt::Feature::RelaxedSimd)
-                    .disable_feature(wasm_opt::Feature::Gc)
-                    .disable_feature(wasm_opt::Feature::ExceptionHandling)
-                    .run(&path, &out);
-
-                if wasm_opt_result.is_ok() {
-                    let original_size = std::fs::metadata(&path).map(|m| m.len());
-                    let new_size = std::fs::metadata(&out).map(|m| m.len());
-
-                    match (new_size, original_size) {
-                        (Ok(new_size), Ok(original_size)) if new_size < original_size => {
-                            let diff = (original_size - new_size) / 1024;
-
-                            if diff > 20 {
-                                diags.emit(
-                                    Diagnostic::warning()
-                                        .with_labels(vec![Label::primary(
-                                            FileId::new(
-                                                None,
-                                                VirtualPath::new(
-                                                    path.strip_prefix(package_dir).error(
-                                                        "internal",
-                                                        "Failed to string prefix",
-                                                    )?,
-                                                ),
-                                            ),
-                                            0..0,
-                                        )])
-                                        .with_code("size/wasm")
-                                        .with_message(format!(
-                                        "This file could be {diff}kB smaller with `wasm-opt -Os`."
-                                    )),
-                                );
-                            }
-                        }
-                        _ => {}
-                    }
-
-                    // TODO: ideally this should be async
-                    std::fs::remove_file(out).ok();
-                }
-            }
-
-            // Don't suggest to exclude WASM files, they are generally necessary
-            // for the package to work.
-            continue;
-        }
-
-        let fid = FileId::new(None, VirtualPath::new(&path));
-
-        let (code, message) = if size > REALLY_LARGE {
-            (
-                "size/extra-large",
-                format!(
-                    "This file is really large ({size}MB). \
-                If possible, do not include it in this repository at all.",
-                    size = size / 1024 / 1024
-                ),
-            )
-        } else if !exclude.matched(path, false).is_ignore() {
-            (
-                "size/large",
-                format!(
-                    "This file is quite large ({size}MB). \
-                If it is not required to use the package \
-                (i.e. it is a documentation file, or part of an example), \
-                it should be added to `exclude` in your `typst.toml`.",
-                    size = size / 1024 / 1024
-                ),
-            )
-        } else {
-            continue;
-        };
-
-        diags.emit(
-            Diagnostic::warning()
-                .with_code(code)
-                .with_labels(vec![Label::primary(fid, 0..0)])
-                .with_message(message),
-        )
-    }
-
-    // Also exclude examples
-    for ch in ignore::WalkBuilder::new(package_dir)
-        .overrides(exclude.clone())
-        .build()
-    {
-        let Ok(ch) = ch else {
-            continue;
-        };
-
-        let Ok(metadata) = ch.metadata() else {
-            continue;
-        };
-
-        if metadata.is_dir() {
-            continue;
-        }
-
-        if template_dir
-            .as_ref()
-            .is_some_and(|template_dir| ch.path().starts_with(template_dir))
-        {
-            // Don't exclude template files, even if they contain "example" or "test" in their name.
-            continue;
-        }
-
-        let relative_path = ch
-            .path()
-            .strip_prefix(package_dir)
-            .error("internal", "Child path is not part of parent path")?;
-
-        let file_name = ch.file_name();
-        let file_name_str = file_name.to_string_lossy();
-        let file_id = FileId::new(None, VirtualPath::new(relative_path));
-        let warning = Diagnostic::warning().with_labels(vec![Label::primary(file_id, 0..0)]);
-        if file_name_str.contains("example") {
-            diags.emit(
-                warning
-                    .clone()
-                    .with_message(
-                        "This file seems to be an example, \
-                    and should probably be added to `exclude` in your `typst.toml`.",
-                    )
-                    .with_code("exclude/example"),
-            );
-            continue;
-        }
-
-        if file_name_str.contains("test") {
-            diags.emit(
-                warning
-                    .clone()
-                    .with_message(
-                        "This file seems to be a test, \
-                    and should probably be added to `exclude` in your `typst.toml`.",
-                    )
-                    .with_code("exclude/test"),
-            );
-            continue;
-        }
-    }
-
-    Ok(())
 }
 
 fn dont_over_exclude(
@@ -778,12 +592,13 @@ fn world_for_template(
 
 fn dont_exclude_template_files(
     diags: &mut Diagnostics,
-    manifest: &toml_edit::Document<&String>,
     package_dir: &Path,
     exclude: &Override,
-) -> Option<()> {
-    let template_root = template_root(package_dir, manifest)?;
-    for entry in ignore::Walk::new(template_root).flatten() {
+    template_dir: PackagePath<&Path>,
+) {
+    for entry in ignore::Walk::new(template_dir.full()).flatten() {
+        let entry_path = PackagePath::from_full(package_dir, entry.path());
+
         // For build artifacts, ask the package author to delete them.
         let ext = entry.path().extension().and_then(|e| e.to_str());
         if matches!(ext, Some("pdf" | "png" | "svg")) && entry.path().with_extension("typ").exists()
@@ -791,10 +606,7 @@ fn dont_exclude_template_files(
             diags.emit(
                 Diagnostic::error()
                     .with_labels(vec![Label::primary(
-                        FileId::new(
-                            None,
-                            VirtualPath::new(entry.path().strip_prefix(package_dir).ok()?),
-                        ),
+                        FileId::new(None, VirtualPath::new(entry_path.relative())),
                         0..0,
                     )])
                     .with_code("files/compilation-artifact")
@@ -809,7 +621,7 @@ fn dont_exclude_template_files(
 
         // For other files, check that they are indeed not excluded.
         if exclude
-            .matched(entry.path(), entry.metadata().ok()?.is_dir())
+            .matched(entry.path(), entry.metadata().is_ok_and(|m| m.is_dir()))
             .is_ignore()
         {
             diags.emit(
@@ -817,25 +629,23 @@ fn dont_exclude_template_files(
                     .with_code("exclude/template")
                     .with_message("This file is part of the template and should not be excluded.")
                     .with_labels(vec![Label::primary(
-                        FileId::new(
-                            None,
-                            VirtualPath::new(entry.path().strip_prefix(package_dir).ok()?),
-                        ),
+                        FileId::new(None, VirtualPath::new(entry_path.relative())),
                         0..0,
                     )]),
             )
         }
     }
-
-    Some(())
 }
 
-fn template_root(package_dir: &Path, manifest: &toml_edit::Document<&String>) -> Option<PathBuf> {
+fn template_root(
+    package_dir: &Path,
+    manifest: &toml_edit::Document<&String>,
+) -> Option<PackagePath> {
     let root = manifest
         .get("template")
         .and_then(|t| t.get("path"))?
         .as_str()?;
-    Some(package_dir.join(root))
+    Some(PackagePath::from_relative(package_dir, root))
 }
 
 fn check_thumbnail(
@@ -844,11 +654,11 @@ fn check_thumbnail(
     manifest_file_id: FileId,
     package_dir: &Path,
     exclude: &Override,
-) -> Option<PathBuf> {
+) -> Option<PackagePath> {
     let thumbnail = manifest.get("template")?.as_table()?.get("thumbnail")?;
-    let thumbnail_path = package_dir.join(thumbnail.as_str()?);
+    let thumbnail_path = PackagePath::from_relative(package_dir, Path::new(thumbnail.as_str()?));
 
-    if !thumbnail_path.exists() {
+    if !thumbnail_path.full().exists() {
         diags.emit(
             Diagnostic::error()
                 .with_labels(vec![Label::primary(manifest_file_id, thumbnail.span()?)])
@@ -869,7 +679,7 @@ fn check_thumbnail(
         )
     }
 
-    if exclude.matched(&thumbnail_path, false).is_ignore() {
+    if exclude.matched(thumbnail_path.full(), false).is_ignore() {
         diags.emit(
             Diagnostic::error()
                 .with_label(Label::primary(manifest_file_id, thumbnail.span()?))
@@ -879,7 +689,7 @@ fn check_thumbnail(
     }
 
     if let Some(root) = template_root(package_dir, manifest) {
-        if thumbnail_path.starts_with(root) {
+        if thumbnail_path.full().starts_with(root.full()) {
             diags.emit(
                 Diagnostic::error()
                     .with_label(Label::primary(manifest_file_id, thumbnail.span()?))

--- a/src/check/manifest.rs
+++ b/src/check/manifest.rs
@@ -1,18 +1,19 @@
+use std::path::PathBuf;
 use std::{ops::Range, path::Path, str::FromStr};
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use ignore::overrides::{Override, OverrideBuilder};
 use reqwest::StatusCode;
-use toml_edit::Item;
+use toml_edit::{Array, Item, Table};
 use tracing::{debug, warn};
 use typst::syntax::{
     package::{PackageSpec, PackageVersion},
     FileId, VirtualPath,
 };
 
-use crate::check::path::PackagePath;
+use crate::check::path::{self, PackagePath};
 use crate::{
-    check::{files, Diagnostics, Result, TryExt},
+    check::{Diagnostics, Result, TryExt},
     world::SystemWorld,
 };
 
@@ -21,11 +22,42 @@ pub struct Worlds {
     pub template: Option<SystemWorld>,
 }
 
+/// A partially parsed manifest with spanned fields.
+#[derive(Debug, Clone)]
+pub struct Manifest {
+    pub package: Spanned<Package>,
+    pub template: Option<Spanned<Template>>,
+}
+
+impl Manifest {
+    pub fn thumbnail(&self) -> Option<Spanned<PackagePath<&Path>>> {
+        let thumbnail = self.template.as_ref()?.thumbnail.as_ref()?;
+        Some(thumbnail.as_ref().map(PackagePath::as_path))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Package {
+    pub entrypoint: Spanned<PackagePath>,
+    pub name: Option<Spanned<String>>,
+    pub version: Option<Spanned<PackageVersion>>,
+    pub exclude: Spanned<Override>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Template {
+    pub path: Option<Spanned<PackagePath>>,
+    /// The package directory of this path is still relative to the package, not
+    /// the template directory.
+    pub entrypoint: Option<Spanned<PackagePath>>,
+    pub thumbnail: Option<Spanned<PackagePath>>,
+}
+
 pub async fn check(
     package_dir: &Path,
     diags: &mut Diagnostics,
     package_spec: Option<&PackageSpec>,
-) -> Result<Worlds> {
+) -> Result<(Manifest, Worlds)> {
     let manifest_path = package_dir.join("typst.toml");
     debug!("Reading manifest at {}", &manifest_path.display());
     let manifest_contents = std::fs::read_to_string(&manifest_path).map_err(|e| {
@@ -38,125 +70,88 @@ pub async fn check(
     let manifest = toml_edit::Document::parse(&manifest_contents)
         .error("manifest/toml-syntax", "Failed to parse manifest contents")?;
 
-    let entrypoint = package_dir.join(
-        manifest
-            .get("package")
-            .and_then(|package| package.get("entrypoint"))
-            .and_then(|entrypoint| entrypoint.as_str())
-            .error(
-                "manifest/package/entrypoint/missing",
-                "Packages must specify an `entrypoint` in their manifest",
-            )?,
-    );
-    let world = SystemWorld::new(entrypoint, package_dir.to_owned()).error(
-        "compile/package-world-init",
-        "Failed to initialize the Typst compiler",
+    let Some(package) = manifest.get_table("package") else {
+        return Err(Diagnostic::error()
+            .with_label(Label::primary(manifest_id(), 0..0))
+            .with_message(
+                "All `typst.toml` manifests must contain a [package] section. \
+                 See the README.md file of this repository for details \
+                 about the manifest format.",
+            )
+            .with_code("manifest/package/missing"));
+    };
+
+    let entrypoint = package.get_str("entrypoint").error(
+        "manifest/package/entrypoint/missing",
+        "Packages must specify an `entrypoint` in their manifest",
     )?;
+    let entrypoint = entrypoint.map(|e| PackagePath::from_relative(package_dir, e));
+    let name = check_name(diags, package, package_spec);
+    let version = check_version(diags, package, package_spec);
+    let exclude = check_exclude(diags, package, package_dir)?;
 
-    let manifest_file_id = FileId::new(None, VirtualPath::new("typst.toml"));
-
-    if !manifest.contains_table("package") {
-        // TODO: this condition is probably unreachable as the program would
-        // have panicked before if the `package` table is missing.
-        diags.emit(
-            Diagnostic::error()
-                .with_labels(vec![Label::primary(manifest_file_id, 0..0)])
-                .with_message(
-                    "All `typst.toml` must contain a [package] section. \
-                    See the README.md file of this repository for details \
-                    about the manifest format.",
-                )
-                .with_code("manifest/package/missing"),
-        );
-        return Ok(Worlds {
-            package: world,
-            template: None,
-        });
-    }
-
-    let name = check_name(diags, manifest_file_id, &manifest, package_spec);
-    let version = check_version(diags, manifest_file_id, &manifest, package_spec);
-
-    check_compiler_version(diags, manifest_file_id, &manifest);
-
-    let res = check_universe_fields(diags, manifest_file_id, &manifest);
-    diags.maybe_emit(res);
+    check_compiler_version(diags, package);
+    check_universe_fields(diags, package);
+    check_repo(diags, package).await;
 
     let res = check_file_names(diags, package_dir);
     diags.maybe_emit(res);
 
-    let (exclude, exclude_span) = read_exclude(diags, manifest_file_id, &manifest, package_dir)?;
-
-    let res = dont_over_exclude(diags, manifest_file_id, &exclude, exclude_span.clone());
+    let res = dont_over_exclude(diags, &exclude);
     diags.maybe_emit(res);
 
-    check_repo(diags, manifest_file_id, &manifest).await;
+    let package = package.map(|_| Package {
+        entrypoint,
+        name,
+        version,
+        exclude,
+    });
 
-    let template_world = if let (Some(name), Some(version)) = (name, version) {
-        let inferred_package_spec = PackageSpec {
-            namespace: "preview".into(),
-            name: name.into(),
-            version,
-        };
-
-        world_for_template(
-            &manifest,
-            package_dir,
-            package_spec.unwrap_or(&inferred_package_spec),
-            exclude.clone(),
-        )
-    } else {
-        None
-    };
-
-    let template_dir = template_root(package_dir, &manifest);
-
-    if let Some(template_dir) = &template_dir {
-        dont_exclude_template_files(diags, package_dir, &exclude, template_dir.as_path());
+    let template = check_template(diags, &manifest, package_dir);
+    if let Some(template) = &template {
+        check_thumbnail(diags, &package.exclude, template);
+        dont_exclude_template_files(diags, package_dir, &package.exclude, template);
     }
-    let thumbnail_path = check_thumbnail(diags, &manifest, manifest_file_id, package_dir, &exclude);
 
-    files::check_files(diags, package_dir, &exclude, thumbnail_path);
+    let world = SystemWorld::new(package.entrypoint.full().to_owned(), package_dir.to_owned())
+        .error(
+            "compile/package-world-init",
+            "Failed to initialize the Typst compiler",
+        )?;
 
-    Ok(Worlds {
+    let template_world = world_for_template(package_dir, package_spec, &package, &template);
+
+    let manifest = Manifest { package, template };
+    let worlds = Worlds {
         package: world,
         template: template_world,
-    })
+    };
+    Ok((manifest, worlds))
 }
 
 fn check_name(
     diags: &mut Diagnostics,
-    manifest_file_id: FileId,
-    manifest: &toml_edit::Document<&String>,
+    package: Spanned<&Table>,
     package_spec: Option<&PackageSpec>,
-) -> Option<String> {
-    let Some(name) = manifest
-        .get("package")
-        .and_then(|package| package.get("name"))
-    else {
+) -> Option<Spanned<String>> {
+    let Some(name) = package.get_spanned("name") else {
         diags.emit(
             Diagnostic::error()
-                .with_labels(vec![Label::primary(manifest_file_id, 0..0)])
+                .with_label(Label::primary(manifest_id(), 0..0))
                 .with_code("manifest/package/name/missing")
                 .with_message(
-                    "All `typst.toml` must contain a `name` field. \
-                    See the README.md file of this repository for details \
-                    about the manifest format.",
+                    "All `typst.toml` manifests must contain a `name` field. \
+                     See the README.md file of this repository for details \
+                     about the manifest format.",
                 ),
         );
         return None;
     };
 
-    let error = Diagnostic::error().with_labels(vec![Label::primary(
-        manifest_file_id,
-        name.span().unwrap_or_default(),
-    )]);
-    let warning = Diagnostic::warning().with_labels(vec![Label::primary(
-        manifest_file_id,
-        name.span().unwrap_or_default(),
-    )]);
+    let error = Diagnostic::error().with_label(Label::primary(manifest_id(), name.span()));
+    let warning = Diagnostic::warning().with_label(Label::primary(manifest_id(), name.span()));
 
-    let Some(name) = name.as_str() else {
+    let Some(name) = name.try_map(Item::as_str) else {
         diags.emit(
             error
                 .with_code("manifest/package/name/type")
@@ -165,13 +160,13 @@ fn check_name(
         return None;
     };
 
-    if name != casbab::kebab(name) {
+    if name.val != casbab::kebab(&name) {
         diags.emit(
             error
                 .clone()
                 .with_code("manifest/package/name/kebab-case")
                 .with_message("Please use kebab-case for package names."),
-        )
+        );
     }
 
     if name.contains("typst") {
@@ -183,7 +178,7 @@ fn check_name(
     }
 
     if let Some(package_spec) = package_spec {
-        if name != package_spec.name {
+        if name.val != package_spec.name {
             diags.emit(
                 error
                     .with_code("manifest/package/name/mismatch")
@@ -203,33 +198,26 @@ fn check_name(
 
 fn check_version(
     diags: &mut Diagnostics,
-    manifest_file_id: FileId,
-    manifest: &toml_edit::Document<&String>,
+    package: Spanned<&Table>,
     package_spec: Option<&PackageSpec>,
-) -> Option<PackageVersion> {
-    let Some(version) = manifest
-        .get("package")
-        .and_then(|package| package.get("version"))
-    else {
+) -> Option<Spanned<PackageVersion>> {
+    let Some(version) = package.get_spanned("version") else {
         diags.emit(
             Diagnostic::error()
-                .with_labels(vec![Label::primary(manifest_file_id, 0..0)])
+                .with_label(Label::primary(manifest_id(), 0..0))
                 .with_code("manifest/package/version/missing")
                 .with_message(
-                    "All `typst.toml` must contain a `version` field. \
-                    See the README.md file of this repository for details \
-                    about the manifest format.",
+                    "All `typst.toml` manifests must contain a `version` field. \
+                     See the README.md file of this repository for details \
+                     about the manifest format.",
                 ),
         );
         return None;
     };
 
-    let error = Diagnostic::error().with_labels(vec![Label::primary(
-        manifest_file_id,
-        version.span().unwrap_or_default(),
-    )]);
+    let error = Diagnostic::error().with_label(Label::primary(manifest_id(), version.span()));
 
-    let Some(version) = version.as_str() else {
+    let Some(version) = version.try_map(Item::as_str) else {
         diags.emit(
             error
                 .with_code("manifest/package/version/type")
@@ -238,7 +226,7 @@ fn check_version(
         return None;
     };
 
-    let Ok(version) = version.parse::<PackageVersion>() else {
+    let Some(version) = version.try_map(|v| v.parse::<PackageVersion>().ok()) else {
         diags.emit(
             error
                 .with_code("manifest/package/version/invalid")
@@ -251,7 +239,7 @@ fn check_version(
     };
 
     if let Some(package_spec) = package_spec {
-        if version != package_spec.version {
+        if version.val != package_spec.version {
             diags.emit(
                 error
                     .with_code("manifest/package/version/mismatch")
@@ -270,26 +258,23 @@ fn check_version(
     Some(version)
 }
 
-fn check_compiler_version(
-    diags: &mut Diagnostics,
-    manifest_file_id: FileId,
-    manifest: &toml_edit::Document<&String>,
-) -> Option<()> {
-    let compiler = manifest.get("package")?.get("compiler")?;
-    let Some(compiler_str) = compiler.as_str() else {
+fn check_compiler_version(diags: &mut Diagnostics, package: Spanned<&Table>) -> Option<()> {
+    let compiler = package.get_spanned("compiler")?;
+
+    let Some(compiler) = compiler.try_map(Item::as_str) else {
         diags.emit(
             Diagnostic::error()
-                .with_labels(vec![Label::primary(manifest_file_id, compiler.span()?)])
+                .with_label(Label::primary(manifest_id(), compiler.span()))
                 .with_code("manifest/package/compiler/type")
                 .with_message("Compiler version should be a string"),
         );
         return None;
     };
 
-    if PackageVersion::from_str(compiler_str).is_err() {
+    if PackageVersion::from_str(&compiler).is_err() {
         diags.emit(
             Diagnostic::error()
-                .with_labels(vec![Label::primary(manifest_file_id, compiler.span()?)])
+                .with_label(Label::primary(manifest_id(), compiler.span()))
                 .with_code("manifest/package/compiler/invalid")
                 .with_message("Compiler version should be a valid semantic version, with three components (for example `0.12.0`)"),
         );
@@ -299,13 +284,8 @@ fn check_compiler_version(
     Some(())
 }
 
-fn dont_over_exclude(
-    diags: &mut Diagnostics,
-    manifest_file_id: FileId,
-    exclude: &Override,
-    span: std::ops::Range<usize>,
-) -> Result<()> {
-    let warning = Diagnostic::warning().with_labels(vec![Label::primary(manifest_file_id, span)]);
+fn dont_over_exclude(diags: &mut Diagnostics, exclude: &Spanned<Override>) -> Result<()> {
+    let warning = Diagnostic::warning().with_label(Label::primary(manifest_id(), exclude.span()));
 
     if exclude.matched("LICENSE", false).is_ignore() {
         diags.emit(
@@ -333,7 +313,7 @@ fn check_file_names(diags: &mut Diagnostics, package_dir: &Path) -> Result<()> {
             let file_id = FileId::new(None, VirtualPath::new(path));
             diags.emit(
                 Diagnostic::error()
-                    .with_labels(vec![Label::primary(file_id, 0..0)])
+                    .with_label(Label::primary(file_id, 0..0))
                     .with_message(message),
             )
         };
@@ -387,30 +367,17 @@ fn check_file_names(diags: &mut Diagnostics, package_dir: &Path) -> Result<()> {
 
 /// Some fields are optional for the bundler, but required to be published in Typst Universe.
 /// Check that they are present.
-fn check_universe_fields(
-    diags: &mut Diagnostics,
-    manifest_file_id: FileId,
-    manifest: &toml_edit::Document<&String>,
-) -> Result<()> {
-    let pkg = manifest
-        .get("package")
-        .error("manifest/package/missing", "[package] not found")?
-        .as_table()
-        .error("manifest/package/invalid-type", "[package] is not a table")?;
-
-    if let Some((license, span)) = pkg
-        .get("license")
-        .and_then(|l| l.as_str().map(|s| (s, l.span().unwrap_or_default())))
-    {
-        if let Ok(license) = spdx::Expression::parse(license) {
-            for requirement in license.requirements() {
+fn check_universe_fields(diags: &mut Diagnostics, package: Spanned<&Table>) {
+    if let Some(license) = package.get_str("license") {
+        if let Ok(spdx_license) = spdx::Expression::parse(&license) {
+            for requirement in spdx_license.requirements() {
                 if let Some(id) = requirement.req.license.id() {
                     if !id.is_osi_approved() {
                         diags.emit(
                             Diagnostic::error()
                                 .with_code("manifest/package/license/osi")
                                 .with_message("The `license` field should be OSI approved")
-                                .with_labels(vec![Label::primary(manifest_file_id, span.clone())]),
+                                .with_label(Label::primary(manifest_id(), license.span())),
                         );
                     }
                 } else {
@@ -418,7 +385,7 @@ fn check_universe_fields(
                         Diagnostic::error()
                             .with_code("manifest/package/license/invalid")
                             .with_message("The `license` field should not contain a referencer")
-                            .with_labels(vec![Label::primary(manifest_file_id, span.clone())]),
+                            .with_label(Label::primary(manifest_id(), license.span())),
                     );
                 }
             }
@@ -427,7 +394,7 @@ fn check_universe_fields(
                 Diagnostic::error()
                     .with_code("manifest/package/license/invalid")
                     .with_message("The `license` field should be a valid SPDX-2 expression")
-                    .with_labels(vec![Label::primary(manifest_file_id, span.clone())]),
+                    .with_label(Label::primary(manifest_id(), license.span())),
             );
         }
     } else {
@@ -435,44 +402,39 @@ fn check_universe_fields(
             Diagnostic::error()
                 .with_code("manifest/package/license/type")
                 .with_message("The `license` field should be a string")
-                .with_labels(vec![Label::primary(manifest_file_id, 0..0)]),
+                .with_label(Label::primary(manifest_id(), package.span())),
         );
     }
 
-    if pkg.get("description").map(|d| !d.is_str()).unwrap_or(true) {
+    if package.get_str("description").is_none() {
         diags.emit(
             Diagnostic::error()
                 .with_code("manifest/package/description/type")
                 .with_message("The `description` field should be a string")
-                .with_labels(vec![Label::primary(manifest_file_id, 0..0)]),
+                .with_label(Label::primary(manifest_id(), package.span())),
         );
     }
 
-    if pkg
-        .get("authors")
-        .and_then(|a| a.as_array())
-        .map(|a| a.iter().any(|item| !item.is_str()))
-        .unwrap_or(true)
+    if package
+        .get_array("authors")
+        .is_none_or(|authors| authors.iter().any(|item| !item.is_str()))
     {
         diags.emit(
             Diagnostic::error()
                 .with_code("manifest/package/authors/type")
                 .with_message("The `authors` field should be an array of strings")
-                .with_labels(vec![Label::primary(manifest_file_id, 0..0)]),
+                .with_label(Label::primary(manifest_id(), package.span())),
         );
         // TODO: check that the format is correct?
     }
-
-    Ok(())
 }
 
 async fn check_url(
     diags: &mut Diagnostics,
-    manifest_file_id: FileId,
-    field: &Item,
-    field_name: &'static str,
+    field: Spanned<&str>,
+    name: &'static str,
 ) -> Option<()> {
-    if let Err(e) = reqwest::get(field.as_str()?)
+    if let Err(e) = reqwest::get(field.val)
         .await
         .and_then(|res| res.error_for_status())
     {
@@ -487,11 +449,8 @@ async fn check_url(
 
         diags.emit(
             Diagnostic::error()
-                .with_labels(vec![Label::primary(
-                    manifest_file_id,
-                    field.span().unwrap_or_default(),
-                )])
-                .with_code(format!("manifest/package/{}/{}", field_name, kind))
+                .with_label(Label::primary(manifest_id(), field.span()))
+                .with_code(format!("manifest/package/{}/{}", name, kind))
                 .with_message(format!(
                     "We could not fetch this URL.\n\nDetails: {:#?}",
                     e.without_url()
@@ -502,47 +461,47 @@ async fn check_url(
     Some(())
 }
 
-async fn check_repo(
-    diags: &mut Diagnostics,
-    manifest_file_id: FileId,
-    manifest: &toml_edit::Document<&String>,
-) -> Option<()> {
-    let repo_field = manifest.get("package")?.get("repository")?;
-    check_url(diags, manifest_file_id, repo_field, "repository").await;
-
-    let homepage_field = manifest.get("package")?.get("homepage")?;
-    check_url(diags, manifest_file_id, homepage_field, "homepage").await;
-
-    if repo_field.as_str() == homepage_field.as_str() {
-        diags.emit(
-            Diagnostic::error()
-                .with_labels(vec![Label::primary(
-                    manifest_file_id,
-                    homepage_field.span().unwrap_or_default(),
-                )])
-                .with_code("manifest/package/homepage/redundant")
-                .with_message("Use the homepage field only if there is a dedicated website. Otherwise, prefer the `repository` field.".to_owned()),
-        )
+async fn check_repo(diags: &mut Diagnostics, package: Spanned<&Table>) {
+    let repo = package.get_str("repository");
+    if let Some(repo) = repo {
+        check_url(diags, repo, "repository").await;
     }
 
-    Some(())
+    if let Some(homepage) = package.get_str("homepage") {
+        check_url(diags, homepage, "homepage").await;
+
+        if repo.is_some_and(|repo| repo.val == homepage.val) {
+            diags.emit(
+                Diagnostic::error()
+                    .with_label(Label::primary(manifest_id(), homepage.span()))
+                    .with_code("manifest/package/homepage/redundant")
+                    .with_message(
+                        "Use the homepage field only if there is a dedicated website. \
+                        Otherwise, prefer the `repository` field.",
+                    ),
+            )
+        }
+    }
 }
 
-fn read_exclude(
+/// This function is fallible, because if exclude parsing fails, there might be
+/// a lot of false positives in other diagnostics.
+fn check_exclude(
     diags: &mut Diagnostics,
-    manifest_file_id: FileId,
-    manifest: &toml_edit::Document<&String>,
+    package: Spanned<&Table>,
     package_dir: &Path,
-) -> Result<(Override, Range<usize>)> {
-    let empty_array = toml_edit::Array::new();
-    let exclude = manifest
-        .get("package")
-        .and_then(|package| package.get("exclude"))
-        .and_then(|item| item.as_array())
-        .unwrap_or(&empty_array);
+) -> Result<Spanned<Override>> {
+    let Some(exclude) = package.get_spanned("exclude") else {
+        return Ok(Spanned::new(Override::empty(), package.span()));
+    };
+
+    let exclude = exclude.try_map(Item::as_array).error(
+        "manifest/package/exclude/type",
+        "`exclude` must be an array of strings",
+    )?;
 
     let mut exclude_globs = OverrideBuilder::new(package_dir);
-    for exclusion in exclude {
+    for exclusion in exclude.iter() {
         let Some(exclusion_str) = exclusion.as_str() else {
             continue;
         };
@@ -557,7 +516,7 @@ fn read_exclude(
             .inspect(|_| {
                 diags.emit(
                     Diagnostic::warning()
-                        .with_label(Label::primary(manifest_file_id, exclusion.span().unwrap_or_default()))
+                        .with_label(Label::primary(manifest_id(), exclusion.span().unwrap_or_default()))
                         .with_code("manifest/package/exclude/leading-dot")
                         .with_message("Leading `./` of exclusions are trimmed. Use an absolute path starting with `/` to avoid recursive matching."),
                 );
@@ -565,28 +524,82 @@ fn read_exclude(
             .unwrap_or(exclusion_str);
         exclude_globs.add(&format!("!{exclusion_str}")).ok();
     }
-    Ok((
-        exclude_globs
-            .build()
-            .error("manifest/exclude/invalid", "Invalid exclude globs")?,
-        exclude.span().unwrap_or(0..0),
-    ))
+
+    let exclude_globs = exclude_globs
+        .build()
+        .error("manifest/package/exclude/invalid", "Invalid exclude globs")?;
+    Ok(exclude.map(|_| exclude_globs))
+}
+
+fn check_template(
+    diags: &mut Diagnostics,
+    manifest: &toml_edit::Document<&String>,
+    package_dir: &Path,
+) -> Option<Spanned<Template>> {
+    let template = manifest.get_spanned("template")?;
+
+    let Some(template) = template.try_map(Item::as_table) else {
+        diags.emit(
+            Diagnostic::error()
+                .with_label(Label::primary(manifest_id(), template.span()))
+                .with_code("manifest/template/type")
+                .with_message("`template` must be a table."),
+        );
+        return None;
+    };
+
+    let path = template.get_str("path").map(|path| {
+        path.map(PathBuf::from)
+            .map(|path| PackagePath::from_relative(package_dir, path))
+    });
+
+    let entrypoint = template.get_str("entrypoint").and_then(|entrypoint| {
+        let template_dir = path.as_ref()?;
+        Some(
+            entrypoint
+                .map(|entrypoint| path::relative_to(template_dir.full(), entrypoint))
+                .map(|path| PackagePath::from_full(package_dir, path)),
+        )
+    });
+
+    let thumbnail = template.get_str("thumbnail").map(|path| {
+        path.map(PathBuf::from)
+            .map(|path| PackagePath::from_relative(package_dir, path))
+    });
+
+    Some(template.map(|_| Template {
+        path,
+        entrypoint,
+        thumbnail,
+    }))
 }
 
 fn world_for_template(
-    manifest: &toml_edit::Document<&String>,
     package_dir: &Path,
-    package_spec: &PackageSpec,
-    exclude: Override,
+    package_spec: Option<&PackageSpec>,
+    package: &Spanned<Package>,
+    template: &Option<Spanned<Template>>,
 ) -> Option<SystemWorld> {
-    let template = manifest.get("template")?.as_table()?;
-    let template_path = package_dir.join(template.get("path")?.as_str()?);
-    let template_main = template_path.join(template.get("entrypoint")?.as_str()?);
+    let name = package.name.as_ref()?;
+    let version = package.version.as_ref()?;
+    let inferred_package_spec = PackageSpec {
+        namespace: "preview".into(),
+        name: name.as_ref().val.into(),
+        version: version.val,
+    };
+    let package_spec = package_spec.unwrap_or(&inferred_package_spec);
 
-    let mut world = SystemWorld::new(template_main, template_path)
-        .ok()?
-        .with_package_override(package_spec, package_dir);
-    world.exclude(exclude);
+    let template = template.as_ref()?;
+    let template_path = template.path.as_ref()?;
+    let template_main = template.entrypoint.as_ref()?;
+
+    let mut world = SystemWorld::new(
+        template_main.full().to_owned(),
+        template_path.full().to_owned(),
+    )
+    .ok()?
+    .with_package_override(package_spec, package_dir);
+    world.exclude(package.exclude.val.clone());
     Some(world)
 }
 
@@ -594,9 +607,13 @@ fn dont_exclude_template_files(
     diags: &mut Diagnostics,
     package_dir: &Path,
     exclude: &Override,
-    template_dir: PackagePath<&Path>,
+    template: &Spanned<Template>,
 ) {
-    for entry in ignore::Walk::new(template_dir.full()).flatten() {
+    let Some(template_path) = &template.path else {
+        return;
+    };
+
+    for entry in ignore::Walk::new(template_path.full()).flatten() {
         let entry_path = PackagePath::from_full(package_dir, entry.path());
 
         // For build artifacts, ask the package author to delete them.
@@ -605,10 +622,7 @@ fn dont_exclude_template_files(
         {
             diags.emit(
                 Diagnostic::error()
-                    .with_labels(vec![Label::primary(
-                        FileId::new(None, VirtualPath::new(entry_path.relative())),
-                        0..0,
-                    )])
+                    .with_label(Label::primary(entry_path.file_id(), 0..0))
                     .with_code("files/compilation-artifact")
                     .with_message(
                         "This file is a compiled document and should \
@@ -628,40 +642,21 @@ fn dont_exclude_template_files(
                 Diagnostic::error()
                     .with_code("exclude/template")
                     .with_message("This file is part of the template and should not be excluded.")
-                    .with_labels(vec![Label::primary(
-                        FileId::new(None, VirtualPath::new(entry_path.relative())),
-                        0..0,
-                    )]),
+                    .with_label(Label::primary(entry_path.file_id(), 0..0)),
             )
         }
     }
 }
 
-fn template_root(
-    package_dir: &Path,
-    manifest: &toml_edit::Document<&String>,
-) -> Option<PackagePath> {
-    let root = manifest
-        .get("template")
-        .and_then(|t| t.get("path"))?
-        .as_str()?;
-    Some(PackagePath::from_relative(package_dir, root))
-}
-
-fn check_thumbnail(
-    diags: &mut Diagnostics,
-    manifest: &toml_edit::Document<&String>,
-    manifest_file_id: FileId,
-    package_dir: &Path,
-    exclude: &Override,
-) -> Option<PackagePath> {
-    let thumbnail = manifest.get("template")?.as_table()?.get("thumbnail")?;
-    let thumbnail_path = PackagePath::from_relative(package_dir, Path::new(thumbnail.as_str()?));
+fn check_thumbnail(diags: &mut Diagnostics, exclude: &Override, template: &Spanned<Template>) {
+    let Some(thumbnail_path) = &template.thumbnail else {
+        return;
+    };
 
     if !thumbnail_path.full().exists() {
         diags.emit(
             Diagnostic::error()
-                .with_labels(vec![Label::primary(manifest_file_id, thumbnail.span()?)])
+                .with_label(Label::primary(manifest_id(), thumbnail_path.span()))
                 .with_code("manifest/template/thumbnail/not-found")
                 .with_message("This file does not exist."),
         )
@@ -673,7 +668,7 @@ fn check_thumbnail(
     ) {
         diags.emit(
             Diagnostic::error()
-                .with_labels(vec![Label::primary(manifest_file_id, thumbnail.span()?)])
+                .with_label(Label::primary(manifest_id(), thumbnail_path.span()))
                 .with_code("manifest/template/thumbnail/format")
                 .with_message("Thumbnails should be PNG or WebP files."),
         )
@@ -682,17 +677,17 @@ fn check_thumbnail(
     if exclude.matched(thumbnail_path.full(), false).is_ignore() {
         diags.emit(
             Diagnostic::error()
-                .with_label(Label::primary(manifest_file_id, thumbnail.span()?))
+                .with_label(Label::primary(manifest_id(), thumbnail_path.span()))
                 .with_code("manifest/template/thumbnail/exclude")
                 .with_message("The template thumbnail is automatically excluded"),
         );
     }
 
-    if let Some(root) = template_root(package_dir, manifest) {
-        if thumbnail_path.full().starts_with(root.full()) {
+    if let Some(template_path) = &template.path {
+        if thumbnail_path.full().starts_with(template_path.full()) {
             diags.emit(
                 Diagnostic::error()
-                    .with_label(Label::primary(manifest_file_id, thumbnail.span()?))
+                    .with_label(Label::primary(manifest_id(), thumbnail_path.span()))
                     .with_code("manifest/template/thumbnail/location")
                     .with_message(
                         "The thumbnail file should be outside of the template directory.\n\n\
@@ -703,6 +698,113 @@ fn check_thumbnail(
             );
         }
     }
+}
 
-    Some(thumbnail_path)
+fn manifest_id() -> FileId {
+    FileId::new(None, VirtualPath::new("typst.toml"))
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct Spanned<T> {
+    pub val: T,
+    /// Don't use [`std::ops::Range`] directly, so we can derive Copy.
+    span: (usize, usize),
+}
+
+impl<T> Spanned<T> {
+    fn new(val: T, span: Range<usize>) -> Self {
+        Self {
+            val,
+            span: (span.start, span.end),
+        }
+    }
+
+    pub fn span(&self) -> Range<usize> {
+        self.span.0..self.span.1
+    }
+
+    pub fn as_ref(&self) -> Spanned<&T> {
+        Spanned {
+            val: &self.val,
+            span: self.span,
+        }
+    }
+
+    pub fn map<F, V>(self, f: F) -> Spanned<V>
+    where
+        F: FnOnce(T) -> V,
+    {
+        Spanned {
+            val: f(self.val),
+            span: self.span,
+        }
+    }
+
+    pub fn try_map<F, V>(self, f: F) -> Option<Spanned<V>>
+    where
+        F: FnOnce(T) -> Option<V>,
+    {
+        Some(Spanned {
+            val: f(self.val)?,
+            span: self.span,
+        })
+    }
+}
+
+impl<T: ?Sized + ToOwned> Spanned<&T> {
+    pub fn to_owned(self) -> Spanned<T::Owned>
+    where
+        T: ToOwned,
+    {
+        Spanned {
+            val: self.val.to_owned(),
+            span: self.span,
+        }
+    }
+}
+
+impl<T> std::ops::Deref for Spanned<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.val
+    }
+}
+
+impl<T> std::ops::DerefMut for Spanned<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.val
+    }
+}
+
+trait TomlExt {
+    fn get_spanned(&self, name: &'static str) -> Option<Spanned<&Item>>;
+
+    fn get_table(&self, name: &'static str) -> Option<Spanned<&Table>>;
+
+    fn get_array(&self, name: &'static str) -> Option<Spanned<&Array>>;
+
+    fn get_str(&self, name: &'static str) -> Option<Spanned<&str>>;
+}
+
+impl TomlExt for Table {
+    fn get_spanned(&self, name: &'static str) -> Option<Spanned<&Item>> {
+        let item = self.get(name)?;
+        // The span should only ever be none for user-created tables, not
+        // deserialized ones.
+        let span = item.span()?;
+        Some(Spanned::new(item, span))
+    }
+
+    fn get_table(&self, name: &'static str) -> Option<Spanned<&Table>> {
+        self.get_spanned(name)?.try_map(Item::as_table)
+    }
+
+    fn get_array(&self, name: &'static str) -> Option<Spanned<&Array>> {
+        self.get_spanned(name)?.try_map(Item::as_array)
+    }
+
+    fn get_str(&self, name: &'static str) -> Option<Spanned<&str>> {
+        self.get_spanned(name)?.try_map(Item::as_str)
+    }
 }

--- a/src/check/path.rs
+++ b/src/check/path.rs
@@ -15,7 +15,7 @@ impl PackagePath<PathBuf> {
     /// Create a new package path from the package directory and a relative path
     /// within the directory.
     pub fn from_relative<T: AsRef<Path>>(package_dir: &Path, relative_path: T) -> Self {
-        let full_path = path_relative_to(package_dir, relative_path.as_ref());
+        let full_path = relative_to(package_dir, relative_path.as_ref());
         let offset = package_dir.components().count();
         Self { offset, full_path }
     }
@@ -31,6 +31,7 @@ impl PackagePath<PathBuf> {
 impl<T: AsRef<Path>> PackagePath<T> {
     /// Create a new package path from the package dir and a full path that has
     /// to start with the package directory.
+    #[track_caller]
     pub fn from_full(package_dir: &Path, full_path: T) -> Self {
         let path = full_path.as_ref();
 
@@ -75,8 +76,9 @@ impl<T: AsRef<Path>> PackagePath<T> {
 /// Strips any any leading root components (`/` or `\`) of the `path` before
 /// joining it to the `root` path. Absolute paths would otherwise replace the
 /// complete path when `join`ed with a parent path.
-pub fn path_relative_to(root: &Path, path: &Path) -> PathBuf {
+pub fn relative_to(root: &Path, path: impl AsRef<Path>) -> PathBuf {
     let components = path
+        .as_ref()
         .components()
         .skip_while(|c| matches!(c, std::path::Component::RootDir))
         .map(|c| Path::new(c.as_os_str()));

--- a/src/check/path.rs
+++ b/src/check/path.rs
@@ -1,0 +1,124 @@
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+use typst::syntax::{FileId, VirtualPath};
+
+/// A path inside a package that allows either retrieving the full or the
+/// package-relative path.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct PackagePath<T = PathBuf> {
+    offset: usize,
+    full_path: T,
+}
+
+impl PackagePath<PathBuf> {
+    /// Create a new package path from the package directory and a relative path
+    /// within the directory.
+    pub fn from_relative<T: AsRef<Path>>(package_dir: &Path, relative_path: T) -> Self {
+        let full_path = path_relative_to(package_dir, relative_path.as_ref());
+        let offset = package_dir.components().count();
+        Self { offset, full_path }
+    }
+
+    pub fn as_path(&self) -> PackagePath<&Path> {
+        PackagePath {
+            offset: self.offset,
+            full_path: self.full_path.as_path(),
+        }
+    }
+}
+
+impl<T: AsRef<Path>> PackagePath<T> {
+    /// Create a new package path from the package dir and a full path that has
+    /// to start with the package directory.
+    pub fn from_full(package_dir: &Path, full_path: T) -> Self {
+        let path = full_path.as_ref();
+
+        path.strip_prefix(package_dir)
+            .expect("full path must start with the pacakge directory");
+
+        let offset = package_dir.components().count();
+        Self { offset, full_path }
+    }
+
+    /// The full path, not necessarily absolute, but it will resolve the file
+    /// from the current directory.
+    pub fn full(&self) -> &Path {
+        self.full_path.as_ref()
+    }
+
+    /// The path relative to the package directory.
+    pub fn relative(&self) -> &Path {
+        let mut components = self.full_path.as_ref().components();
+        for _ in 0..self.offset {
+            components.next();
+        }
+        components.as_path()
+    }
+
+    pub fn file_name(&self) -> &OsStr {
+        self.full()
+            .file_name()
+            .expect("package path must be file or directory within a package")
+    }
+
+    pub fn extension(&self) -> Option<&OsStr> {
+        self.full().extension()
+    }
+
+    /// The [`FileId`] of the package relative path.
+    pub fn file_id(&self) -> FileId {
+        FileId::new(None, VirtualPath::new(self.relative()))
+    }
+}
+
+/// Strips any any leading root components (`/` or `\`) of the `path` before
+/// joining it to the `root` path. Absolute paths would otherwise replace the
+/// complete path when `join`ed with a parent path.
+pub fn path_relative_to(root: &Path, path: &Path) -> PathBuf {
+    let components = path
+        .components()
+        .skip_while(|c| matches!(c, std::path::Component::RootDir))
+        .map(|c| Path::new(c.as_os_str()));
+
+    PathBuf::from_iter(std::iter::once(root).chain(components))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_relative() {
+        #[track_caller]
+        fn test_relative(root: &str, relative: &str) {
+            let path = PackagePath::from_relative(Path::new(root), relative);
+            assert_eq!(path.full(), "/root/path/to/package/src/thing.typ");
+            assert_eq!(path.relative(), "src/thing.typ");
+        }
+
+        test_relative("/root/path/to/package/", "/src/thing.typ");
+        test_relative("/root/path/to/package/", "src/thing.typ");
+        test_relative("/root/path/to/package", "/src/thing.typ");
+        test_relative("/root/path/to/package", "src/thing.typ");
+    }
+
+    #[test]
+    fn from_full() {
+        #[track_caller]
+        fn test_full(root: &str, relative: &str) {
+            let path = PackagePath::from_full(Path::new(root), relative);
+            assert_eq!(path.full(), "/root/path/to/package/src/thing.typ");
+            assert_eq!(path.relative(), "src/thing.typ");
+        }
+
+        test_full(
+            "/root/path/to/package/",
+            "/root/path/to/package/src/thing.typ",
+        );
+        test_full(
+            "/root/path/to/package",
+            "/root/path/to/package/src/thing.typ",
+        );
+    }
+}

--- a/src/check/readme.rs
+++ b/src/check/readme.rs
@@ -19,20 +19,23 @@ use crate::{
     world::SystemWorld,
 };
 
-pub async fn check_readme(
-    world: &SystemWorld,
-    diags: &mut Diagnostics,
-) -> crate::check::Result<()> {
+#[derive(Default)]
+pub struct Readme {
+    pub text: String,
+    pub linked_files: Vec<PackagePath>,
+}
+
+pub async fn check(world: &SystemWorld, diags: &mut Diagnostics) -> crate::check::Result<Readme> {
     // check syntax, versions and kebab-case
     // warn on unsupported gfm features
-    let readme = tokio::fs::read_to_string(world.root().join("README.md"))
+    let text = tokio::fs::read_to_string(world.root().join("README.md"))
         .await
         .error("io/readme", "Failed to read README.md")?;
 
     let arena = comrak::Arena::new();
     let md_ast = comrak::parse_document(
         &arena,
-        &readme,
+        &text,
         &comrak::Options {
             // Try to be faithful to the Universe parser
             extension: comrak::options::Extension {
@@ -51,6 +54,11 @@ pub async fn check_readme(
             ..Default::default()
         },
     );
+
+    let mut readme = Readme {
+        text,
+        linked_files: Vec::new(),
+    };
 
     for node in md_ast.descendants() {
         let md_node = &*node.data.borrow();
@@ -87,7 +95,7 @@ pub async fn check_readme(
             }
             // Check if all links are valid.
             MdNode::Link(link) => {
-                check_readme_link_url(world, diags, &readme, md_node.sourcepos, &link.url);
+                check_readme_link_url(world, diags, &mut readme, md_node.sourcepos, &link.url);
             }
             // Check all image URLs are valid and alt text is specified.
             MdNode::Image(link) => {
@@ -100,19 +108,19 @@ pub async fn check_readme(
                 }
                 check_image_alternative_description(diags, &readme, md_node.sourcepos, &alt);
 
-                check_readme_link_url(world, diags, &readme, md_node.sourcepos, &link.url);
+                check_readme_link_url(world, diags, &mut readme, md_node.sourcepos, &link.url);
             }
             MdNode::HtmlBlock(html) => {
-                check_readme_html(world, diags, &readme, md_node.sourcepos, &html.literal);
+                check_readme_html(world, diags, &mut readme, md_node.sourcepos, &html.literal);
             }
             MdNode::HtmlInline(html) => {
-                check_readme_html(world, diags, &readme, md_node.sourcepos, html);
+                check_readme_html(world, diags, &mut readme, md_node.sourcepos, html);
             }
             _ => (),
         }
     }
 
-    Ok(())
+    Ok(readme)
 }
 
 fn check_readme_code_block(
@@ -176,7 +184,7 @@ fn check_readme_code_block(
 fn check_readme_html(
     world: &SystemWorld,
     diags: &mut Diagnostics,
-    readme: &str,
+    readme: &mut Readme,
     sourcepos: Sourcepos,
     html: &str,
 ) {
@@ -203,7 +211,7 @@ fn check_readme_html(
 fn check_html_elems(
     world: &SystemWorld,
     diags: &mut Diagnostics,
-    readme: &str,
+    readme: &mut Readme,
     sourcepos: Sourcepos,
     node: &markup5ever_rcdom::Node,
 ) {
@@ -243,7 +251,7 @@ fn check_html_elems(
 fn check_readme_link_url(
     world: &SystemWorld,
     diags: &mut Diagnostics,
-    readme: &str,
+    readme: &mut Readme,
     sourcepos: Sourcepos,
     url_text: &str,
 ) {
@@ -310,11 +318,13 @@ fn check_readme_link_url(
                 )]),
         );
     }
+
+    readme.linked_files.push(path);
 }
 
 const DEFAULT_BRANCHES: [&str; 2] = ["main", "master"];
 
-fn check_repo_file_url(diags: &mut Diagnostics, readme: &str, sourcepos: Sourcepos, url: &str) {
+fn check_repo_file_url(diags: &mut Diagnostics, readme: &Readme, sourcepos: Sourcepos, url: &str) {
     static GITHUB_URL: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"https://github.com/([^/]+)/([^/]+)/(?:blob|tree)/([^/]+)/(.+)").unwrap()
     });
@@ -390,7 +400,7 @@ fn check_repo_file_url(diags: &mut Diagnostics, readme: &str, sourcepos: Sourcep
 
 fn check_image_alternative_description(
     diags: &mut Diagnostics,
-    readme: &str,
+    readme: &Readme,
     sourcepos: Sourcepos,
     alt: &str,
 ) {
@@ -430,7 +440,7 @@ fn check_image_alternative_description(
     }
 }
 
-fn sourcepos_to_range(s: &str, pos: Sourcepos) -> Range<usize> {
+fn sourcepos_to_range(readme: &Readme, pos: Sourcepos) -> Range<usize> {
     fn byte_offset(s: &str, pos: LineColumn) -> usize {
         // `LineColumn` uses 1-indexed line numbers.
         let line_offset = s
@@ -443,9 +453,9 @@ fn sourcepos_to_range(s: &str, pos: Sourcepos) -> Range<usize> {
     }
 
     // `LineColumn::column` is 1-indexed.
-    let start = byte_offset(s, pos.start) - 1;
+    let start = byte_offset(&readme.text, pos.start) - 1;
     // `Sourcepos::end` is end-inclusive (byte-wise), and thus `offset + 1 - 1`.
-    let end = byte_offset(s, pos.end);
+    let end = byte_offset(&readme.text, pos.end);
 
     start..end
 }

--- a/src/check/readme.rs
+++ b/src/check/readme.rs
@@ -1,5 +1,4 @@
 use std::io::Cursor;
-use std::path::Path;
 use std::sync::LazyLock;
 use std::{collections::HashSet, ops::Range};
 
@@ -14,7 +13,7 @@ use typst::{
 };
 use url::Url;
 
-use crate::check::files;
+use crate::check::path::PackagePath;
 use crate::{
     check::{imports, kebab_case, label, Diagnostics, TryExt},
     world::SystemWorld,
@@ -294,7 +293,8 @@ fn check_readme_link_url(
     }
 
     // Check if the local file exists.
-    if !files::path_relative_to(world.root(), Path::new(absolute_path)).exists() {
+    let path = PackagePath::from_relative(world.root(), absolute_path);
+    if !path.full().exists() {
         diags.emit(
             Diagnostic::error()
                 .with_code("readme/link/file-not-found")

--- a/tests/ref/local+fifth+0.1.0.txt
+++ b/tests/ref/local+fifth+0.1.0.txt
@@ -1,1 +1,1 @@
-Fatal error: Packages must specify an `entrypoint` in their manifest
+Fatal error: All `typst.toml` manifests must contain a [package] section. See the README.md file of this repository for details about the manifest format.

--- a/tests/ref/local+first+0.1.0.txt
+++ b/tests/ref/local+first+0.1.0.txt
@@ -2,19 +2,19 @@ error[manifest/package/license/type]: The `license` field should be a string
   ┌─ typst.toml:1:0
   │
 1 │ [package]
-  │ ^
+  │ ^^^^^^^^^
 
 error[manifest/package/description/type]: The `description` field should be a string
   ┌─ typst.toml:1:0
   │
 1 │ [package]
-  │ ^
+  │ ^^^^^^^^^
 
 error[manifest/package/authors/type]: The `authors` field should be an array of strings
   ┌─ typst.toml:1:0
   │
 1 │ [package]
-  │ ^
+  │ ^^^^^^^^^
 
 error[manifest/template/thumbnail/not-found]: This file does not exist.
   ┌─ typst.toml:7:12

--- a/tests/ref/local+second+0.2.1.txt
+++ b/tests/ref/local+second+0.2.1.txt
@@ -26,5 +26,5 @@ error[manifest/package/authors/type]: The `authors` field should be an array of 
   ┌─ typst.toml:1:0
   │
 1 │ [package]
-  │ ^
+  │ ^^^^^^^^^
 

--- a/tests/ref/preview+aero-navigator+0.1.0.txt
+++ b/tests/ref/preview+aero-navigator+0.1.0.txt
@@ -1,3 +1,9 @@
+warning[files/manual/unlinked]: This file seems to be a manual/documentation, but isn't linked in the readme. It will be inacessible on Typst Universe.
+  ┌─ docs/manual.pdf:1:0
+  │
+1 │ 
+  │ ^
+
 error[readme/image/missing-alt]: Missing alternative description for image. Please add a short description to make this image more accessible.
    ┌─ README.md:16:0
    │  

--- a/tests/ref/preview+mythographer-5e+0.0.1.txt
+++ b/tests/ref/preview+mythographer-5e+0.0.1.txt
@@ -1,15 +1,3 @@
-warning[size/large]: This file is quite large (1MB). If it is not required to use the package (i.e. it is a documentation file, or part of an example), it should be added to `exclude` in your `typst.toml`.
-  ┌─ assets/paper/default.jpg:1:0
-  │
-1 │ 
-  │ ^
-
-warning[size/large]: This file is quite large (1MB). If it is not required to use the package (i.e. it is a documentation file, or part of an example), it should be added to `exclude` in your `typst.toml`.
-  ┌─ assets/paper/toa.jpg:1:0
-  │
-1 │ 
-  │ ^
-
 warning[readme/link/repository-url-permalink]: GitHub URL links to default branch: `https://github.com/sa1g/dnd-typst-template/tree/master/fonts`.
 
 Consider using a link to a specific tag/release or a permalink to a commit instead. This will ensure that the linked resource always matches this version of the package.
@@ -21,6 +9,18 @@ Alternatively you can also link to a local file. This is preferred if the linked
    │
 38 │ They can be found in [/fonts](https://github.com/sa1g/dnd-typst-template/tree/master/fonts) folder of the repository.
    │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning[size/large]: This file is quite large (1MB). If it is not required to use the package (i.e. it is a documentation file, or part of an example), it should be added to `exclude` in your `typst.toml`.
+  ┌─ assets/paper/default.jpg:1:0
+  │
+1 │ 
+  │ ^
+
+warning[size/large]: This file is quite large (1MB). If it is not required to use the package (i.e. it is a documentation file, or part of an example), it should be added to `exclude` in your `typst.toml`.
+  ┌─ assets/paper/toa.jpg:1:0
+  │
+1 │ 
+  │ ^
 
 error[compile/error]: The following error was reported by the Typst compiler: failed to download package (All packages are supposed to be present in the `packages` repository, or in the local cache.)
   ┌─ lib/config.typ:3:8


### PR DESCRIPTION
Closes #50

Initially I just wanted to implement the warning for unlinked manuals/docs, which needs both information from the manifest and the readme. Looking at the code, I thought I'd just refactor the manifest and readme checks to generate output. That got a bit out of hand, and turned into quite large changes :sweat_smile:

The fundamental refactors are:
- A `PackagePath` struct that allows both retrieving the full path and the path relative to the package directory. This cleared things up quite a bit for me, because previously it was a little bit of a guessing game if a `Path` was relative or not.
- A` Spanned` struct that wraps a value and associates it with a `Range<usize>`, which is extensively used when parsing the TOML manifest.
- The manifest and readme checks return the parsed and validated information, which can be used in other checks.

I still think these refactors are worth while, and allow to more easily add more complex checks in the future.