### PR TITLE
Make outdated imports of the checked package an error and other ones a hint

### DIFF
--- a/src/check/imports.rs
+++ b/src/check/imports.rs
@@ -3,7 +3,7 @@ use std::{
     str::FromStr,
 };
 
-use codespan_reporting::diagnostic::Diagnostic;
+use codespan_reporting::diagnostic::{Diagnostic, Severity};
 use typst::{
     World,
     syntax::{
@@ -91,8 +91,15 @@ pub fn check_ast(
                 latest_package_version(all_packages, import_spec.versionless())
             && latest_version > import_spec.version
         {
+            // Generate an error if an old version of the package is imported.
+            // For other packages this usually isn't an issue, so only notify
+            // package authors.
+            let severity = match world.package_spec() {
+                Some(spec) if import_spec.versionless() == spec.versionless() => Severity::Error,
+                _ => Severity::Note,
+            };
             diags.emit(
-                Diagnostic::warning()
+                Diagnostic::new(severity)
                     .with_labels(label(world, import.span()).into_iter().collect())
                     .with_code("import/outdated")
                     .with_message("This import seems to use an older version of the package."),

--- a/src/check/manifest.rs
+++ b/src/check/manifest.rs
@@ -110,11 +110,25 @@ pub async fn check(
         dont_exclude_template_files(diags, package_dir, &package.exclude, template);
     }
 
-    let world = SystemWorld::new(package.entrypoint.full().to_owned(), package_dir.to_owned())
-        .error(
-            "compile/package-world-init",
-            "Failed to initialize the Typst compiler",
-        )?;
+    let package_spec = package_spec.cloned().or_else(|| {
+        let name = package.name.as_ref()?;
+        let version = package.version.as_ref()?;
+        Some(PackageSpec {
+            namespace: "preview".into(),
+            name: name.as_ref().val.into(),
+            version: version.val,
+        })
+    });
+
+    let world = SystemWorld::new(
+        package.entrypoint.full().to_owned(),
+        package_dir.to_owned(),
+        package_spec.clone(),
+    )
+    .error(
+        "compile/package-world-init",
+        "Failed to initialize the Typst compiler",
+    )?;
 
     let template_world = world_for_template(package_dir, package_spec, &package, &template);
 
@@ -658,19 +672,11 @@ fn check_template(
 
 fn world_for_template(
     package_dir: &Path,
-    package_spec: Option<&PackageSpec>,
+    package_spec: Option<PackageSpec>,
     package: &Spanned<Package>,
     template: &Option<Spanned<Template>>,
 ) -> Option<SystemWorld> {
-    let name = package.name.as_ref()?;
-    let version = package.version.as_ref()?;
-    let inferred_package_spec = PackageSpec {
-        namespace: "preview".into(),
-        name: name.as_ref().val.into(),
-        version: version.val,
-    };
-    let package_spec = package_spec.unwrap_or(&inferred_package_spec);
-
+    let package_spec = package_spec?;
     let template = template.as_ref()?;
     let template_path = template.path.as_ref()?;
     let template_main = template.entrypoint.as_ref()?;
@@ -678,9 +684,10 @@ fn world_for_template(
     let mut world = SystemWorld::new(
         template_main.full().to_owned(),
         template_path.full().to_owned(),
+        Some(package_spec),
     )
     .ok()?
-    .with_package_override(package_spec, package_dir);
+    .with_package_override(package_dir.to_owned());
     world.exclude(package.exclude.val.clone());
     Some(world)
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -204,10 +204,10 @@ mod json {
         serde_json::to_writer(
             &mut *w,
             &JsonDiagnostic {
-                kind: if diag.severity == Severity::Error {
-                    "error"
-                } else {
-                    "warning"
+                kind: match diag.severity {
+                    Severity::Help | Severity::Note => "note",
+                    Severity::Warning => "warning",
+                    Severity::Error | Severity::Bug => "error",
                 },
                 location,
                 message: &diag.message,

--- a/src/github.rs
+++ b/src/github.rs
@@ -474,10 +474,10 @@ fn diagnostic_to_annotation(
         end_line: end_line + 1,
         start_column,
         end_column,
-        annotation_level: if diag.severity == Severity::Warning {
-            AnnotationLevel::Warning
-        } else {
-            AnnotationLevel::Failure
+        annotation_level: match diag.severity {
+            Severity::Help | Severity::Note => AnnotationLevel::Notice,
+            Severity::Warning => AnnotationLevel::Warning,
+            Severity::Error | Severity::Bug => AnnotationLevel::Failure,
         },
         message: diag.message.clone(),
     })

--- a/src/github/api/check.rs
+++ b/src/github/api/check.rs
@@ -41,6 +41,7 @@ pub struct Annotation {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AnnotationLevel {
+    Notice,
     Warning,
     Failure,
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -43,15 +43,21 @@ pub struct SystemWorld {
     /// always the same within one compilation.
     /// Reset between compilations if not [`Now::Fixed`].
     now: typst_kit::datetime::Time,
+    /// The package specification of the currently checked package.
+    package_spec: Option<PackageSpec>,
     /// Override for package resolution
-    package_override: Option<(PackageSpec, PathBuf)>,
+    package_override: Option<PathBuf>,
     /// Files that are considered excluded and should not be read from.
     exclude: Exclude,
 }
 
 impl SystemWorld {
     /// Create a new system world.
-    pub fn new(input: PathBuf, root: PathBuf) -> Result<Self, WorldCreationError> {
+    pub fn new(
+        input: PathBuf,
+        root: PathBuf,
+        package_spec: Option<PackageSpec>,
+    ) -> Result<Self, WorldCreationError> {
         // Resolve the virtual path of the main file within the project root.
         let main_path =
             VirtualPath::virtualize(&root, &input).or(Err(WorldCreationError::InputOutsideRoot))?;
@@ -70,13 +76,14 @@ impl SystemWorld {
             fonts: searcher.fonts,
             slots: Mutex::new(HashMap::new()),
             now: typst_kit::datetime::Time::system(),
+            package_spec,
             package_override: None,
             exclude: Exclude::empty(),
         })
     }
 
-    pub fn with_package_override(mut self, spec: &PackageSpec, dir: &Path) -> Self {
-        self.package_override = Some((spec.clone(), dir.to_owned()));
+    pub fn with_package_override(mut self, dir: PathBuf) -> Self {
+        self.package_override = Some(dir);
         self
     }
 
@@ -102,6 +109,16 @@ impl SystemWorld {
     pub fn virtual_line(&self, id: FileId) -> usize {
         self.slot(id, |f| f.line_shift)
     }
+
+    pub fn package_spec(&self) -> Option<&PackageSpec> {
+        self.package_spec.as_ref()
+    }
+
+    pub fn package_override(&self) -> Option<(&PackageSpec, &Path)> {
+        self.package_spec
+            .as_ref()
+            .zip(self.package_override.as_deref())
+    }
 }
 
 impl World for SystemWorld {
@@ -119,13 +136,13 @@ impl World for SystemWorld {
 
     fn source(&self, id: FileId) -> FileResult<Source> {
         self.slot(id, |slot| {
-            slot.source(&self.root, &self.package_override, &self.exclude)
+            slot.source(&self.root, self.package_override(), &self.exclude)
         })
     }
 
     fn file(&self, id: FileId) -> FileResult<Bytes> {
         self.slot(id, |slot| {
-            slot.file(&self.root, &self.package_override, &self.exclude)
+            slot.file(&self.root, self.package_override(), &self.exclude)
         })
     }
 
@@ -177,7 +194,7 @@ impl FileSlot {
     fn source(
         &mut self,
         project_root: &Path,
-        package_override: &Option<(PackageSpec, PathBuf)>,
+        package_override: Option<(&PackageSpec, &Path)>,
         exclude: &Exclude,
     ) -> FileResult<Source> {
         self.source.get_or_init(
@@ -214,7 +231,7 @@ impl FileSlot {
     fn file(
         &mut self,
         project_root: &Path,
-        package_override: &Option<(PackageSpec, PathBuf)>,
+        package_override: Option<(&PackageSpec, &Path)>,
         exclude: &Exclude,
     ) -> FileResult<Bytes> {
         self.file.get_or_init(
@@ -279,7 +296,7 @@ impl<T: Clone> SlotCell<T> {
 /// Resolves the path of a file id on the system, downloading a package if
 /// necessary.
 fn system_path(
-    package_override: &Option<(PackageSpec, PathBuf)>,
+    package_override: Option<(&PackageSpec, &Path)>,
     project_root: &Path,
     exclude: &Exclude,
     id: FileId,
@@ -303,10 +320,10 @@ fn system_path(
     // Determine the root path relative to which the file path
     // will be resolved.
     let root = if let VirtualRoot::Package(spec) = id.root() {
-        if let Some(package_override) = package_override
-            && *spec == package_override.0
+        if let Some((override_spec, override_dir)) = package_override
+            && spec == override_spec
         {
-            return exclude(id, &package_override.1);
+            return exclude(id, override_dir);
         }
 
         expect_parents(
@@ -355,7 +372,7 @@ fn expect_parents<'a>(dir: &'a Path, parents: &'a [&'a str]) -> Option<PathBuf> 
 fn read(
     id: FileId,
     project_root: &Path,
-    package_override: &Option<(PackageSpec, PathBuf)>,
+    package_override: Option<(&PackageSpec, &Path)>,
     exclude: &Exclude,
 ) -> FileResult<Vec<u8>> {
     read_from_disk(&system_path(package_override, project_root, exclude, id)?)

--- a/tests/local/first/0.1.0/lib.typ
+++ b/tests/local/first/0.1.0/lib.typ
@@ -1,1 +1,4 @@
+// Outdated import
+#import "@local/second:0.1.0"
+
 #let add = (a, b) => a + b

--- a/tests/local/second/0.1.0/LICENSE
+++ b/tests/local/second/0.1.0/LICENSE
@@ -1,0 +1,1 @@
+totally an MIT license

--- a/tests/local/second/0.1.0/README.md
+++ b/tests/local/second/0.1.0/README.md
@@ -1,0 +1,3 @@
+# second
+
+Have a look at the [wikipedia article](https://en.wikipedia.org/wiki/Second) about the SI unit.

--- a/tests/local/second/0.1.0/lib.typ
+++ b/tests/local/second/0.1.0/lib.typ
@@ -1,0 +1,1 @@
+#let Tick(t) = calc.rem(t + 1, 60)

--- a/tests/local/second/0.1.0/typst.toml
+++ b/tests/local/second/0.1.0/typst.toml
@@ -1,0 +1,6 @@
+[package]
+name = "second"
+license = "MIT"
+version = "0.1.0"
+entrypoint = "lib.typ"
+description = "Hi"

--- a/tests/ref/local+first+0.1.0.txt
+++ b/tests/ref/local+first+0.1.0.txt
@@ -4,6 +4,12 @@ error[compile/error]: The following error was reported by the Typst compiler: fa
 1 │ #import "@preview/first:0.1.0": add as add
   │         ^^^^^^^^^^^^^^^^^^^^^^
 
+note[import/outdated]: This import seems to use an older version of the package.
+  ┌─ lib.typ:2:1
+  │
+2 │ #import "@local/second:0.1.0"
+  │  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[manifest/template/thumbnail/not-found]: This file does not exist.
   ┌─ typst.toml:7:12
   │

--- a/tests/ref/preview+cheq+0.2.0.txt
+++ b/tests/ref/preview+cheq+0.2.0.txt
@@ -72,15 +72,15 @@ If this code block is not supposed to be parsed as a Typst source, please explic
 152 │ #let checked-sym(fill: white, stroke: rgb("#616161"), radius: .1em) = { .. }
     │                                                                         ^^
 
-warning[import/outdated]: This import seems to use an older version of the package.
-   ┌─ README.md:53:1
-   │
-53 │ #import "@preview/cheq:0.1.0": checklist
-   │  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 warning[manifest/package/exclude/leading-dot]: Leading `./` of exclusions are trimmed. Use an absolute path starting with `/` to avoid recursive matching.
   ┌─ typst.toml:6:11
   │
 6 │ exclude = ["./examples"]
   │            ^^^^^^^^^^^^
+
+error[import/outdated]: This import seems to use an older version of the package.
+   ┌─ README.md:53:1
+   │
+53 │ #import "@preview/cheq:0.1.0": checklist
+   │  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Generate an error if an old version of the checked package is imported, this is pretty much always an issue with the template or a readme example. For other packages this usually isn't urgent so only generate a note for the package authors.