### PR TITLE
Refactor Nix flake: extract package, apply best practices

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,41 +18,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,31 +3,41 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, utils }:
-    let cargoMeta = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-    in utils.lib.eachDefaultSystem (system:
-      let pkgs = nixpkgs.legacyPackages.${system};
-      in {
-        packages = rec {
+  outputs =
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      inherit (nixpkgs) lib;
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = lib.genAttrs supportedSystems;
+    in
+    {
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
+
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        rec {
           default = typst-package-check;
-          typst-package-check = pkgs.rustPlatform.buildRustPackage {
-            pname = cargoMeta.package.name;
-            version = cargoMeta.package.version;
-            src = ./.;
-            nativeBuildInputs = [ pkgs.pkg-config ];
-            buildInputs = [ pkgs.openssl.dev pkgs.git ];
-            cargoHash = "sha256-RMjZLacXHStsPyK5R0T++mr2yLlJE52xpcK1sqJ57Fw=";
-            # Don't run `cargo test`, as there are no tests to run.
-            doCheck = false;
-          };
+
+          typst-package-check = pkgs.callPackage ./package.nix { };
+
           docker-image = pkgs.dockerTools.buildImage {
             name = "ghcr.io/typst/package-check";
             tag = typst-package-check.version;
-            copyToRoot = with pkgs.dockerTools; [
-              caCertificates
+            copyToRoot = [
+              pkgs.dockerTools.caCertificates
               pkgs.gitMinimal
               pkgs.bashNonInteractive
               pkgs.busybox
@@ -38,6 +48,7 @@
               WorkingDir = "/data";
             };
           };
-        };
-      });
+        }
+      );
+    };
 }

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  openssl,
+}:
+let
+  cargoMeta = lib.importTOML ./Cargo.toml;
+in
+rustPlatform.buildRustPackage {
+  pname = cargoMeta.package.name;
+  inherit (cargoMeta.package) version;
+  src = ./.;
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+  cargoHash = "sha256-7lpmevoAZ0pRTdpSx17IhhwdqhcVVsvoqHUci+Makf8=";
+  # Don't run `cargo test`, as there are no tests to run.
+  doCheck = false;
+}


### PR DESCRIPTION
- Fix outdated cargoHash and modernize buildInputs
- Extract package definition from flake.nix into standalone package.nix to allow non-flake usage
- Add nixfmt-tree as the default formatter and apply formatting to all Nix files
- Remove flake-utils input; inline system iteration via lib.genAttrs with an explicit supportedSystems list
- Eliminate 'with pkgs.dockerTools;' in docker-image copyToRoot for clarity